### PR TITLE
The build folder is required to build packages

### DIFF
--- a/packaging/centos7/cloud.spec
+++ b/packaging/centos7/cloud.spec
@@ -162,6 +162,7 @@ echo Doing CloudStack build
 
 %build
 
+mkdir -p build
 cp packaging/centos7/replace.properties build/replace.properties
 echo VERSION=%{_maventag} >> build/replace.properties
 echo PACKAGE=%{name} >> build/replace.properties


### PR DESCRIPTION
It was missing from repo due to .gitignore but still depends on its
existence.
