### PR TITLE
CLOUDSTACK-9256 add unique key for static routes in json

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 def merge(dbag, staticroutes):
     for route in staticroutes['routes']:
-        key = route['ip_address']
+        key = route['network']
         revoke = route['revoke']
         if revoke:
             try:


### PR DESCRIPTION
This was PR 1364 at Apache CloudStack.
