### PR TITLE
Make /32 static routes for private gw work

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -85,13 +85,13 @@ class CsStaticRoutes(CsDataBag):
 
     def __update(self, route):
         if route['revoke']:
-            command = "route del -net %s gw %s" % (route['network'], route['gateway'])
+            command = "ip route del %s via %s" % (route['network'], route['gateway'])
             result = CsHelper.execute(command)
         else:
             command = "ip route show | grep %s | awk '{print $1, $3}'" % route['network']
             result = CsHelper.execute(command)
             if not result:
-                route_command = "route add -net %s gw %s" % (route['network'], route['gateway'])
+                route_command = "ip route add %s via %s" % (route['network'], route['gateway'])
                 result = CsHelper.execute(route_command)
 
 


### PR DESCRIPTION
Static routes for private gateways that were /32 failed because the `route` command used had `-net` in it and a `/32` requires `-host` instead. I rewrote it to `ip` commands.

Tested the following static routes:
<img width="766" alt="screen shot 2016-01-29 at 21 12 15" src="https://cloud.githubusercontent.com/assets/1630096/12686942/1f0c9a3c-c6cd-11e5-9b65-60e813fdde47.png">

Both show up fine now:
<img width="590" alt="screen shot 2016-01-29 at 21 09 46" src="https://cloud.githubusercontent.com/assets/1630096/12686949/26a0d998-c6cd-11e5-9fa9-b89f0382a726.png">

Backport from PR 1383 to ACS upstream.
