### PR TITLE
Display hostname the VPC router runs on

### DIFF
--- a/ui/scripts/network.js
+++ b/ui/scripts/network.js
@@ -5859,6 +5859,9 @@
                                     linklocalip: {
                                         label: 'label.linklocal.ip'
                                     },
+                                    hostname: {
+                                        label: 'label.host'
+                                    },
                                     state: {
                                         label: 'label.state'
                                     },


### PR DESCRIPTION
This is displayed on Infra tab and it's annoying that on the VPC page only the link local is mentioned and not the hostname. That is now corrected, so you have the correct details to login to the router straight away.

Before:
<img width="702" alt="screen shot 2016-01-29 at 20 58 58" src="https://cloud.githubusercontent.com/assets/1630096/12687083/f7de5760-c6cd-11e5-9f62-cdf2cce8aeed.png">

After:
<img width="704" alt="screen shot 2016-01-29 at 21 18 21" src="https://cloud.githubusercontent.com/assets/1630096/12687088/fc4d1c1e-c6cd-11e5-8573-cdde638264f7.png">

So the option 'Host' was added and displays the hypervisor the VPC runs on.

Backport from PR 1384 to ACS upstream.
