### PR TITLE
Make s2s VPN CIDR list longer

### DIFF
--- a/setup/db/db/schema-480to500.sql
+++ b/setup/db/db/schema-480to500.sql
@@ -1,3 +1,4 @@
 --;
 -- Schema upgrade from 4.8.0 to 5.0.0;
 --;
+ALTER TABLE `s2s_customer_gateway` MODIFY `guest_cidr_list` VARCHAR(4096);


### PR DESCRIPTION
Found this issue on our backlog and did a bit of investigation. Fixing this was easy, so went ahead and did it.

123.123.123.123/24 ==> 18 chars + comma = 19 chars per cidr max.

Was: 200/19 = ~10
Now: 4096/19 = ~215
