### PR TITLE
Correct location of build.properties

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -212,7 +212,7 @@
                   <globmapper from="*.in" to="*" />
                   <filterchain>
                     <filterreader classname="org.apache.tools.ant.filters.ReplaceTokens">
-                      <param type="propertiesfile" value="${project.basedir}/../${cs.replace.properties}" />
+                      <param type="propertiesfile" value="${cs.replace.properties}" />
                     </filterreader>
                   </filterchain>
                 </copy>


### PR DESCRIPTION
Working!

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:21 min (Wall Clock)
[INFO] Finished at: 2016-02-08T08:24:41+01:00
[INFO] Final Memory: 83M/1396M
[INFO] ------------------------------------------------------------------------
```

This is in the past now:

```
java.io.FileNotFoundException: /Users/bschrijver/github.com/MissionCriticalCloud/cosmic/cosmic-core/server/../build/replace.properties (No such file or directory)
    at java.io.FileInputStream.open0(Native Method)
    at java.io.FileInputStream.open(FileInputStream.java:195)
    at java.io.FileInputStream.<init>(FileInputStream.java:138)
    at org.apache.tools.ant.types.resources.FileResource.getInputStream(FileResource.java:217)
    at org.apache.tools.ant.filters.ReplaceTokens.getProperties(ReplaceTokens.java:252)
    at org.apache.tools.ant.filters.ReplaceTokens.makeTokensFromProperties(ReplaceTokens.java:341)
    at org.apache.tools.ant.filters.ReplaceTokens.initialize(ReplaceTokens.java:332)
    at org.apache.tools.ant.filters.ReplaceTokens.read(ReplaceTokens.java:124)
    at org.apache.tools.ant.filters.BaseFilterReader.read(BaseFilterReader.java:83)
    at java.io.BufferedReader.read1(BufferedReader.java:210)
    at java.io.BufferedReader.read(BufferedReader.java:286)
    at org.apache.tools.ant.util.ResourceUtils.copyWithFilterChainsOrTranscoding(ResourceUtils.java:754)
    at org.apache.tools.ant.util.ResourceUtils.copyResource(ResourceUtils.java:425)
    at org.apache.tools.ant.util.FileUtils.copyFile(FileUtils.java:559)
    at org.apache.tools.ant.taskdefs.Copy.doFileOperations(Copy.java:890)
    at org.apache.tools.ant.taskdefs.Copy.execute(Copy.java:563)
    at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
    at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
    at org.apache.tools.ant.Task.perform(Task.java:348)
    at org.apache.tools.ant.Target.execute(Target.java:435)
    at org.apache.tools.ant.Target.performTasks(Target.java:456)
    at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1393)
    at org.apache.tools.ant.Project.executeTarget(Project.java:1364)
    at org.apache.maven.plugin.antrun.AntRunMojo.execute(AntRunMojo.java:313)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:185)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:181)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```
