### PR TITLE
Improve error message when creating port forwarding rule

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/command/user/firewall/CreatePortForwardingRuleCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/firewall/CreatePortForwardingRuleCmd.java
@@ -139,6 +139,11 @@ public class CreatePortForwardingRuleCmd extends BaseAsyncCreateCmd implements P
         return ipAddressId;
     }
 
+    public String getIpAddressUuid() {
+        IpAddress ip = _networkService.getIp(ipAddressId);
+        return ip.getUuid();
+    }
+
     public Ip getVmSecondaryIp() {
         if (vmSecondaryIp == null) {
             return null;
@@ -294,8 +299,8 @@ public class CreatePortForwardingRuleCmd extends BaseAsyncCreateCmd implements P
             ntwkId = networkId;
         }
         if (ntwkId == null) {
-            throw new InvalidParameterValueException("Unable to create port forwarding rule for the ipAddress id=" + ipAddressId +
-                    " as ip is not associated with any network and no networkId is passed in");
+            throw new InvalidParameterValueException("Unable to create port forwarding rule for ip address with ID = " + getIpAddressUuid() +
+                    " as this ip address is not associated with any network. Please add networkId parameter.");
         }
         return ntwkId;
     }


### PR DESCRIPTION
The error message outputs integer IDs (mysql index id) that a user cannot relate to a UUID. Changed the code to use a UUID instead.

Command:
`create portforwardingrule virtualmachineid=ebdad66c-eda5-4610-901b-81a4fea78fe5 ipaddressid=f5f5c9e9-f407-4f9c-a10e-940bb184d19e publicport=22 privateport=22 protocol=tcp`

Error before:
`Error 431: Unable to create port forwarding rule for the ipAddress id=4 as ip is not associated with any network and no networkId is passed in`

Error after:
`Error 431: Unable to create port forwarding rule for ip address 'f5f5c9e9-f407-4f9c-a10e-940bb184d19e' as this ip address is not associated with any network. Please add networkId parameter.`

PS: Don't worry, I'm not working. Just experimenting with Java/IntelliJ/Cosmic and was looking for unimportant easy-to-fix stuff to try out some things.  Feel free to close if it's crap ;-)
