### PR TITLE
CLOUDSTACK-9285 Make the Agent reconnect instead of die

### DIFF
--- a/agent/src/main/java/com/cloud/agent/Agent.java
+++ b/agent/src/main/java/com/cloud/agent/Agent.java
@@ -227,7 +227,7 @@ public class Agent implements HandlerFactory, IAgentControl {
         try {
             _connection.start();
         } catch (final NioConnectionException e) {
-            throw new CloudRuntimeException("Unable to start the connection!", e);
+            s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
         }
         while (!_connection.isStartup()) {
             _shell.getBackoffAlgorithm().waitBeforeRetry();
@@ -235,7 +235,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
-                throw new CloudRuntimeException("Unable to start the connection!", e);
+                s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
             }
         }
     }
@@ -412,7 +412,7 @@ public class Agent implements HandlerFactory, IAgentControl {
             try {
                 _connection.start();
             } catch (final NioConnectionException e) {
-                throw new CloudRuntimeException("Unable to start the connection!", e);
+                s_logger.info("Attempted to connect to the server, but received an unexpected exception, trying again...");
             }
             _shell.getBackoffAlgorithm().waitBeforeRetry();
         } while (!_connection.isStartup());


### PR DESCRIPTION
Backport of PR 1430 from ACS

Making a PR in order to test it against Cosmic. We also see this with the systemvms that won't reconnect properly after a war drop. They don't seem to handle the disconnect to one management server properly. Instead of reconnecting, they die with an exception.
