### PR TITLE
Redundant passwd server

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -62,7 +62,7 @@ class CsPassword(CsDataBag):
             proc = CsProcess(['/opt/cloud/bin/passwd_server_ip.py', server_ip])
             if proc.find():
                 update_command = 'curl --header "DomU_Request: save_password" "http://{SERVER_IP}:8080/" -F "ip={VM_IP}" -F "password={PASSWORD}" ' \
-                '-F "token={TOKEN}" >/dev/null 2>/dev/null &'.format(SERVER_IP=server_ip, VM_IP=vm_ip, PASSWORD=password, TOKEN=token)
+                '-F "token={TOKEN}" --interface 127.0.0.1 >/dev/null 2>/dev/null &'.format(SERVER_IP=server_ip, VM_IP=vm_ip, PASSWORD=password, TOKEN=token)
                 result = CsHelper.execute(update_command)
                 logging.debug("Update password server result ==> %s" % result)
 

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -241,6 +241,7 @@ class CsRedundant(object):
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
             CsPasswdSvc(interface.get_gateway()).stop()
+            CsPasswdSvc(interface.get_ip()).stop()
 
         self.cl.set_fault_state()
         self.cl.save()
@@ -277,6 +278,7 @@ class CsRedundant(object):
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
             CsPasswdSvc(interface.get_gateway()).stop()
+            CsPasswdSvc(interface.get_ip()).stop()
         CsHelper.service("dnsmasq", "stop")
 
         self.cl.set_master_state(False)
@@ -332,7 +334,10 @@ class CsRedundant(object):
         CsHelper.service("xl2tpd", "restart")
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
+            # Listen on gateway and local ip address, as cloud-init uses the 'dhcp-server-identifier' address,
+            #  which unfortunately is not the gateway address.
             CsPasswdSvc(interface.get_gateway()).restart()
+            CsPasswdSvc(interface.get_ip()).restart()
 
         CsHelper.service("dnsmasq", "restart")
         self.cl.set_master_state(True)


### PR DESCRIPTION
This PR makes the password service work on redundant VPCs.

Issue 1: not allowed to set passwd because interface was unauthorised. Adding `--interface 127.0.0.1` makes sure it's always allowd.

Issue 2: passwd server not listening on ip address of guest tier (the guest uses that to connect instead of the gateway ip address). We now run passwd server on both and both get the passwd set.
