### PR TITLE
Fix problem when removing tiers

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/merge.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/merge.py
@@ -305,7 +305,7 @@ class PrivateGatewayHack:
 
         initial_data = cls.load_inital_data()
         has_private_gw_ip = cls.if_config_has_privategateway(initial_data)
-        private_gw_matches = cls.ip_matches_private_gateway_ip(ip, initial_data['config']['privategateway'])
+        private_gw_matches = 'privategateway' in initial_data['config'] and cls.ip_matches_private_gateway_ip(ip, initial_data['config']['privategateway'])
 
         if has_private_gw_ip and private_gw_matches:
             data['nw_type'] = "public"


### PR DESCRIPTION
Older VPCs don't have the privategateway cmd_line parameter so we added
a check for it here.

Error seen:

```
File \"/opt/cloud/bin/merge.py\", line 151, in processGuestNetwork\n    dp = PrivateGatewayHack.update_network_type_for_privategateway(dbag, dp)\n  File \"/opt/cloud/bin/merge.py\", line 309, in update_network_type_for_privategateway\n    private_gw_matches = cls.ip_matches_private_gateway_ip(ip, initial_data['config']['privategateway'])\nKeyError: 'privategatew
```

In the UI deleting failed:

![screen shot 2016-03-18 at 14 22 39](https://cloud.githubusercontent.com/assets/1630096/13879183/66979626-ed16-11e5-83e7-c3a141d6f17e.png)

With this PR it succeeds:

![screen shot 2016-03-18 at 14 30 55](https://cloud.githubusercontent.com/assets/1630096/13879185/6ae46d6c-ed16-11e5-9145-5c2dd7a39083.png)

Will send a PR to Cosmic as well.
