### PR TITLE
Print stack traces instead of array with stack trace lines

### DIFF
--- a/tools/marvin/marvin/cloudstackConnection.py
+++ b/tools/marvin/marvin/cloudstackConnection.py
@@ -29,9 +29,7 @@ from marvin.codes import (
     JOB_CANCELLED,
     JOB_SUCCEEDED
 )
-from marvin.cloudstackException import (
-    InvalidParameterException,
-    GetDetailExceptionInfo)
+from marvin.cloudstackException import InvalidParameterException
 
 
 class CSConnection(object):
@@ -231,8 +229,7 @@ class CSConnection(object):
                 return FAILED
         except Exception as e:
             self.__lastError = e
-            self.logger.exception("__sendCmdToCS: Exception:%s" %
-                                  GetDetailExceptionInfo(e))
+            self.logger.exception("__sendCmdToCS: Exception: %s" % e)
             return FAILED
 
     def __sanitizeCmd(self, cmd):
@@ -285,10 +282,7 @@ class CSConnection(object):
             return cmd_name.strip(), isAsync, payload
         except Exception as e:
             self.__lastError = e
-            self.logger.\
-                exception("__sanitizeCmd: CmdName : "
-                          "%s : Exception:%s" % (cmd_name,
-                                                 GetDetailExceptionInfo(e)))
+            self.logger.exception("__sanitizeCmd: CmdName : %s : Exception: %s" % (cmd_name, e))
             return FAILED
 
     def __parseAndGetResponse(self, cmd_response, response_cls, is_async):
@@ -322,8 +316,7 @@ class CSConnection(object):
                 return response.jobresult if response != FAILED else FAILED
         except Exception as e:
             self.__lastError = e
-            self.logger.\
-                exception("Exception:%s" % GetDetailExceptionInfo(e))
+            self.logger.exception("Exception: %s" % e)
             return FAILED
 
     def marvinRequest(self, cmd, response_type=None, method='GET', data=''):
@@ -374,6 +367,5 @@ class CSConnection(object):
                 raise self.__lastError
             return ret
         except Exception as e:
-            self.logger.exception("marvinRequest : CmdName: %s Exception: %s" %
-                                  (str(cmd), GetDetailExceptionInfo(e)))
+            self.logger.exception("marvinRequest : CmdName: %s Exception: %s" % (str(cmd), e))
             raise e

--- a/tools/marvin/marvin/cloudstackException.py
+++ b/tools/marvin/marvin/cloudstackException.py
@@ -59,8 +59,14 @@ class internalError(Exception):
 def GetDetailExceptionInfo(e):
     if e is not None:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        return str(repr(traceback.format_exception(
-            exc_type, exc_value, exc_traceback)))
+        return str(repr(traceback.print_exception(exc_type, exc_value, exc_traceback)))
+    else:
+        return EXCEPTION_OCCURRED
+
+def printException(e):
+    if e is not None:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return str(repr(traceback.print_exception(exc_type, exc_value, exc_traceback)))
     else:
         return EXCEPTION_OCCURRED
 
@@ -87,4 +93,3 @@ class CloudstackAclException():
             return True
         else:
             return False
-

--- a/tools/marvin/marvin/cloudstackTestClient.py
+++ b/tools/marvin/marvin/cloudstackTestClient.py
@@ -22,7 +22,7 @@ from marvin.cloudstackAPI import *
 from marvin.codes import (FAILED, PASS, ADMIN, DOMAIN_ADMIN,
                           USER, SUCCESS, XEN_SERVER)
 from marvin.configGenerator import ConfigManager
-from marvin.cloudstackException import GetDetailExceptionInfo
+from marvin.cloudstackException import printException
 from marvin.lib.utils import (random_gen, validateList)
 from marvin.cloudstackAPI.cloudstackAPIClient import CloudStackAPIClient
 import copy
@@ -115,8 +115,7 @@ class CSTestClient(object):
                 self.__hypervisor = XEN_SERVER
             return SUCCESS
         except Exception as e:
-            print "\n Exception Occurred Under __setHypervisorInfo " \
-                  "%s" % GetDetailExceptionInfo(e)
+            printException(e)
             return FAILED
 
     def __createApiClient(self):
@@ -174,9 +173,7 @@ class CSTestClient(object):
                 self.__apiClient = CloudStackAPIClient(self.__csConnection)
             return SUCCESS
         except Exception as e:
-            self.__logger.exception(" Exception Occurred Under "
-                                    "__createApiClient: %s" %
-                                    GetDetailExceptionInfo(e))
+            printException(e)
             return FAILED
 
     def __createDbConnection(self):
@@ -212,8 +209,7 @@ class CSTestClient(object):
                 return FAILED
             return (register_user_res.apikey, register_user_res.secretkey)
         except Exception as e:
-            self.__logger.exception("Exception Occurred Under __geKeys : "
-                                    "%s" % GetDetailExceptionInfo(e))
+            printException(e)
             return FAILED
 
     def createTestClient(self):
@@ -270,9 +266,7 @@ class CSTestClient(object):
                     debug("==== Test Client Creation Successful ====")
             return ret
         except Exception as e:
-            self.__logger.exception("Exception Occurred "
-                                    "Under createTestClient "
-                                    ": %s" % GetDetailExceptionInfo(e))
+            printException(e)
             return FAILED
 
     def isAdminContext(self):
@@ -376,9 +370,7 @@ class CSTestClient(object):
             self.__userApiClient.hypervisor = self.__hypervisor
             return self.__userApiClient
         except Exception as e:
-            self.__logger.exception("Exception Occurred "
-                                    "Under getUserApiClient : %s" %
-                                    GetDetailExceptionInfo(e))
+            printException(e)
             return FAILED
 
     def close(self):

--- a/tools/marvin/marvin/configGenerator.py
+++ b/tools/marvin/marvin/configGenerator.py
@@ -20,7 +20,7 @@ import os
 from optparse import OptionParser
 import jsonHelper
 from marvin.codes import *
-from marvin.cloudstackException import GetDetailExceptionInfo
+from marvin.cloudstackException import printException
 from marvin.config.test_data import test_data
 
 
@@ -388,9 +388,7 @@ class ConfigManager(object):
                 config = json.loads("\n".join(configLines))
                 config_dict = config
         except Exception as e:
-            # Will replace with log once we have logging done
-            print "\n Exception occurred under ConfigManager:__parseConfig" \
-                  " :%s", GetDetailExceptionInfo(e)
+            printException(e)
         finally:
             return config_dict
 
@@ -931,8 +929,7 @@ def getSetupConfig(file):
         config = json.loads("\n".join(configLines))
         return jsonHelper.jsonLoader(config)
     except Exception as e:
-        print "\nException Occurred under getSetupConfig %s" % \
-              GetDetailExceptionInfo(e)
+        printException(e)
 
 if __name__ == "__main__":
     parser = OptionParser()

--- a/tools/marvin/marvin/deployAndRun.py
+++ b/tools/marvin/marvin/deployAndRun.py
@@ -23,7 +23,7 @@ import random
 from collections import OrderedDict
 from marvin.marvinInit import MarvinInit
 from marvin.deployDataCenter import DeployDataCenters
-from marvin.cloudstackException import GetDetailExceptionInfo
+from marvin.cloudstackException import printException
 from marvin.codegenerator import CodeGenerator
 from marvin.codes import (SUCCESS,
                           FAILED,
@@ -246,8 +246,7 @@ class MarvinCli(cmd.Cmd, object):
                 return SUCCESS
             return FAILED
         except Exception as e:
-            print "====Exception Occurred under start_marvin: %s ====" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
             return FAILED
 
     def run_test_suites(self):

--- a/tools/marvin/marvin/deployDataCenter.py
+++ b/tools/marvin/marvin/deployDataCenter.py
@@ -28,7 +28,7 @@ class DeleteDataCenters: Deletes a DataCenter based upon the dc cfg
 from marvin import configGenerator
 from marvin.cloudstackException import (
     InvalidParameterException,
-    GetDetailExceptionInfo)
+    printException)
 from marvin.cloudstackAPI import *
 from marvin.codes import (FAILED, SUCCESS)
 from marvin.lib.utils import (random_gen)
@@ -78,8 +78,7 @@ class DeployDataCenters(object):
                     "\n=== Data Center Settings are dumped to %s===" %
                     dc_file_path)
         except Exception as e:
-            print "Exception Occurred  while persisting DC Settings: %s" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
 
     def __cleanAndExit(self):
         try:
@@ -104,8 +103,7 @@ class DeployDataCenters(object):
                         "===Removing DataCenter Successful===")
             exit(1)
         except Exception as e:
-            print "Exception Occurred during DC CleanUp: %s" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
 
     def __addToCleanUp(self, type, id):
         if type not in self.__cleanUp.keys():
@@ -139,10 +137,8 @@ class DeployDataCenters(object):
                     self.__addToCleanUp("Host", ret[0].id)
             except Exception as e:
                 failed_cnt = failed_cnt + 1
-                print "Exception Occurred :%s" % GetDetailExceptionInfo(e)
-                self.__tcRunLogger.exception(
-                    "=== Adding Host Failed :%s===" % str(
-                        host.url))
+                printException(e)
+                self.__tcRunLogger.exception("=== Adding Host Failed :%s===" % str(host.url))
                 if failed_cnt == len(hosts):
                     self.__cleanAndExit()
                 continue
@@ -160,7 +156,7 @@ class DeployDataCenters(object):
                 self.__tcRunLogger.debug("=== Adding VmWare DC Successful===")
                 self.__addToCleanUp("VmwareDc", ret.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("=== Adding VmWare DC Failed===")
             self.__cleanAndExit()
 
@@ -198,10 +194,8 @@ class DeployDataCenters(object):
                                            podId,
                                            clusterId)
         except Exception as e:
-            print "Exception Occurred %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.exception("====Cluster %s Creation Failed"
-                                         "=====" %
-                                         str(cluster.clustername))
+            printException(e)
+            self.__tcRunLogger.exception("==== Cluster %s Creation Failed =====" % str(cluster.clustername))
             self.__cleanAndExit()
 
     def waitForHost(self, zoneId, clusterId):
@@ -221,8 +215,7 @@ class DeployDataCenters(object):
                 sleep(timeout)
                 retry = retry - 1
         except Exception as e:
-            print "\nException Occurred:%s" %\
-                  GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("=== List Hosts Failed===")
             self.__cleanAndExit()
 
@@ -257,9 +250,8 @@ class DeployDataCenters(object):
                         "=== Creating Storage Pool Successful===")
                     self.__addToCleanUp("StoragePool", ret.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.\
-                exception("=== Create Storage Pool Failed===")
+            printException(e)
+            self.__tcRunLogger.exception("=== Create Storage Pool Failed===")
             self.__cleanAndExit()
 
     def createPods(self,
@@ -290,10 +282,8 @@ class DeployDataCenters(object):
                 self.createClusters(pod.clusters, zoneId, podId,
                                     vmwareDc=pod.vmwaredc)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.\
-                exception("====Pod: %s Creation "
-                          "Failed=====" % str(pod.name))
+            printException(e)
+            self.__tcRunLogger.exception("==== Pod: %s Creation Failed =====" % str(pod.name))
             self.__cleanAndExit()
 
     def createVlanIpRanges(self, mode, ipranges, zoneId, podId=None,
@@ -326,9 +316,8 @@ class DeployDataCenters(object):
                         "=== Creating Vlan Ip Range Successful===")
                     self.__addToCleanUp("VlanIpRange", ret.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.\
-                exception("=== Create Vlan Ip Range Failed===")
+            printException(e)
+            self.__tcRunLogger.exception("=== Create Vlan Ip Range Failed===")
             self.__cleanAndExit()
 
     def createSecondaryStorages(self, secondaryStorages, zoneId):
@@ -351,13 +340,11 @@ class DeployDataCenters(object):
                     secondarycmd.zoneid = zoneId
                 ret = self.__apiClient.addImageStore(secondarycmd)
                 if ret.id:
-                    self.__tcRunLogger.debug(
-                        "===Add Image Store Successful===")
+                    self.__tcRunLogger.debug("=== Add Image Store Successful ===")
                     self.__addToCleanUp("ImageStore", ret.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.\
-                exception("=== Add Image Store Failed===")
+            printException(e)
+            self.__tcRunLogger.exception("=== Add Image Store Failed ===")
             self.__cleanAndExit()
 
     def createCacheStorages(self, cacheStorages, zoneId):
@@ -380,11 +367,10 @@ class DeployDataCenters(object):
                                                 })
                 ret = self.__apiClient.createSecondaryStagingStore(cachecmd)
                 if ret.id:
-                    self.__tcRunLogger.debug(
-                        "===Creating Secondary StagingStore Successful===")
+                    self.__tcRunLogger.debug("===Creating Secondary StagingStore Successful===")
                     self.__addToCleanUp("SecondaryStagingStore", ret.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception("=== Creating "
                           "SecondaryStagingStorage Failed===")
@@ -417,10 +403,8 @@ class DeployDataCenters(object):
                     self.__addToCleanUp("Network", networkId)
                     return networkId
         except Exception as e:
-            print "Exception Occurred %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.\
-                exception("====Network : %s "
-                          "Creation Failed=====" % str(network.name))
+            printException(e)
+            self.__tcRunLogger.exception("==== Network : %s Creation Failed =====" % str(network.name))
             self.__cleanAndExit()
 
     def createPhysicalNetwork(self, net, zoneid):
@@ -439,9 +423,8 @@ class DeployDataCenters(object):
             self.addTrafficTypes(phynetwrk.id, net.traffictypes)
             return phynetwrk
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.exception("====Physical Network "
-                                         "Creation Failed=====")
+            printException(e)
+            self.__tcRunLogger.exception("====Physical Network Creation Failed=====")
             self.__cleanAndExit()
 
     def updatePhysicalNetwork(self, networkid, state="Enabled",
@@ -455,7 +438,7 @@ class DeployDataCenters(object):
             ret = self.__apiClient.updatePhysicalNetwork(upnet)
             return ret
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception("====Update Physical Network Failed=====")
             self.__cleanAndExit()
@@ -471,7 +454,7 @@ class DeployDataCenters(object):
                 self.__tcRunLogger.debug(
                     "===Update Network Service Provider Successfull===")
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception(
                     "====Update Network Service Provider Failed=====")
@@ -611,7 +594,7 @@ class DeployDataCenters(object):
                                     "type" % device)
                     self.enableProvider(result.id)
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception("====List Network "
                           "Service Providers Failed=====")
@@ -640,7 +623,7 @@ class DeployDataCenters(object):
                 self.__addToCleanUp("TrafficType", ret.id)
                 return ret
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception("==== Add TrafficType Failed=====")
             self.__cleanAndExit()
@@ -655,7 +638,7 @@ class DeployDataCenters(object):
                 self.__tcRunLogger.debug("==== Enable Zone SuccessFul=====")
                 return ret
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("==== Enable Zone Failed=====")
             self.__cleanAndExit()
 
@@ -669,7 +652,7 @@ class DeployDataCenters(object):
                 self.__tcRunLogger.debug("=== Update Zone SuccessFul===")
                 return ret
         except Exception as e:
-            print "Exception Occurred: %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("==== Update Zone  Failed=====")
             self.__cleanAndExit()
 
@@ -696,8 +679,7 @@ class DeployDataCenters(object):
                         str(zone.name)
                     return self.createZone(zone, 1)
         except Exception as e:
-            print "\nException Occurred under createZone : %s" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("====Create Zone Failed ===")
             return FAILED
 
@@ -811,7 +793,7 @@ class DeployDataCenters(object):
                     self.updateZoneDetails(zoneId, det)
             return
         except Exception as e:
-            print "\nException Occurred %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.exception("==== Create Zones Failed ===")
 
     def isEipElbZone(self, zone):
@@ -841,7 +823,7 @@ class DeployDataCenters(object):
                     self.__tcRunLogger.debug(
                         "==UpdateConfiguration Successfull===")
         except Exception as e:
-            print "Exception Occurred %s" % GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.\
                 exception("===UpdateConfiguration Failed===")
             self.__cleanAndExit()
@@ -890,8 +872,7 @@ class DeployDataCenters(object):
             self.__tcRunLogger.debug("\n====Deploy DC Successful====")
             return SUCCESS
         except Exception as e:
-            print "\nException Occurred Under deploy :%s" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
             self.__tcRunLogger.debug("\n====Deploy DC Failed====")
             print "\n====Deploy DC Failed===="
             self.__cleanAndExit()
@@ -1024,11 +1005,7 @@ class DeleteDataCenters:
                                 (type, id))
             ret = SUCCESS
         except Exception as e:
-            print "\n==== Exception Under __cleanEntries: %s ==== % " \
-                  % GetDetailExceptionInfo(e)
-            self.__tcRunLogger.exception(
-                "\n==== Exception Under __cleanEntries: %s ==== % " %
-                GetDetailExceptionInfo(e))
+            printException(e)
         finally:
             return ret
 
@@ -1051,11 +1028,7 @@ class DeleteDataCenters:
             if self.__dcCfg:
                 ret = self.__cleanEntries()
         except Exception as e:
-            print "\n==== Exception Under removeDataCenter: %s ====" % \
-                  GetDetailExceptionInfo(e)
-            self.__tcRunLogger.exception(
-                "===DeployDC CleanUp FAILED: %s ====" %
-                GetDetailExceptionInfo(e))
+            printException(e)
         finally:
             return ret
 

--- a/tools/marvin/marvin/marvinPlugin.py
+++ b/tools/marvin/marvin/marvinPlugin.py
@@ -27,7 +27,7 @@ from marvin.codes import (SUCCESS,
                           FAILED,
                           EXCEPTION)
 from marvin.lib.utils import random_gen
-from marvin.cloudstackException import GetDetailExceptionInfo
+from marvin.cloudstackException import printException
 
 
 class MarvinPlugin(Plugin):
@@ -135,11 +135,7 @@ class MarvinPlugin(Plugin):
     def __checkImport(self, filename):
         '''
         @Name : __checkImport
-        @Desc : Verifies to run the available test module for any Import
-                Errors before running and check
-                whether if it is importable.
-                This will check for test modules which has some issues to be
-                getting imported.
+        @Desc : Verifies if a test module is importable.
                 Returns False or True based upon the result.
         '''
         try:
@@ -150,8 +146,8 @@ class MarvinPlugin(Plugin):
                     return True
             return False
         except ImportError as e:
-            print "FileName :%s : Error : %s" % \
-                  (filename, GetDetailExceptionInfo(e))
+            print "File %s has import errors, detailed exception:" % filename
+            printException(e)
             return False
 
     def wantFile(self, filename):
@@ -187,10 +183,8 @@ class MarvinPlugin(Plugin):
 
     def printMsg(self, status, tname, err):
         if status in [FAILED, EXCEPTION] and self.__tcRunLogger:
-            self.__tcRunLogger.\
-                fatal("%s: %s: %s" % (status,
-                                      tname,
-                                      GetDetailExceptionInfo(err)))
+            printException(err)
+            self.__tcRunLogger.fatal("%s: %s: %s" % (status, tname, err))
         write_str = "=== TestName: %s | Status : %s ===\n" % (tname, status)
         self.__resultStream.write(write_str)
         print write_str
@@ -206,7 +200,7 @@ class MarvinPlugin(Plugin):
         '''
         Adds Exception throwing test cases and information to log.
         '''
-        self.printMsg(EXCEPTION, self.__testName, GetDetailExceptionInfo(err))
+        self.printMsg(EXCEPTION, self.__testName, err)
         self.__testResult = EXCEPTION
 
     def prepareTestRunner(self, runner):
@@ -217,7 +211,7 @@ class MarvinPlugin(Plugin):
         '''
         Adds Failing test cases and information to log.
         '''
-        self.printMsg(FAILED, self.__testName, GetDetailExceptionInfo(err))
+        self.printMsg(FAILED, self.__testName, err)
         self.__testResult = FAILED
 
     def startMarvin(self):
@@ -250,8 +244,7 @@ class MarvinPlugin(Plugin):
                 return SUCCESS
             return FAILED
         except Exception as e:
-            print "Exception Occurred under startMarvin: %s" % \
-                  GetDetailExceptionInfo(e)
+            printException(e)
             return FAILED
 
     def stopTest(self, test):
@@ -308,5 +301,4 @@ class MarvinPlugin(Plugin):
             os.system(cmd)
             print "===final results are now copied to: %s===" % str(dst)
         except Exception as e:
-            print "=== Exception occurred under finalize :%s ===" % \
-                  str(GetDetailExceptionInfo(e))
+            printException(e)

--- a/tools/marvin/marvin/sshClient.py
+++ b/tools/marvin/marvin/sshClient.py
@@ -26,7 +26,7 @@ import socket
 import time
 from marvin.cloudstackException import (
     internalError,
-    GetDetailExceptionInfo
+    printException
 )
 import contextlib
 import logging
@@ -133,22 +133,18 @@ class SshClient(object):
                 ret = SUCCESS
                 break
             except BadHostKeyException as e:
-                except_msg = GetDetailExceptionInfo(e)
+                printException(e)
             except AuthenticationException as e:
-                except_msg = GetDetailExceptionInfo(e)
+                printException(e)
             except SSHException as e:
-                except_msg = GetDetailExceptionInfo(e)
+                printException(e)
             except socket.error as e:
-                except_msg = GetDetailExceptionInfo(e)
+                printException(e)
             except Exception as e:
-                except_msg = GetDetailExceptionInfo(e)
+                printException(e)
             finally:
                 if self.retryCnt == 0 or ret == SUCCESS:
                     break
-                if except_msg != '':
-                    self.logger.\
-                        exception("SshClient: Exception under "
-                                  "createConnection: %s" % except_msg)
                 self.retryCnt -= 1
                 time.sleep(self.delay)
         return ret
@@ -180,12 +176,9 @@ class SshClient(object):
                 if stderr is not None:
                     ret["stderr"] = stderr.readlines()
         except Exception as e:
-            ret["stderr"] = GetDetailExceptionInfo(e)
-            self.logger.exception("SshClient: Exception under runCommand :%s" %
-                                  GetDetailExceptionInfo(e))
+            printException(e)
         finally:
-            self.logger.debug(" Host: %s Cmd: %s Output:%s" %
-                              (self.host, command, str(ret)))
+            self.logger.debug(" Host: %s Cmd: %s Output:%s" % (self.host, command, str(ret)))
             return ret
 
     def scp(self, srcFile, destPath):


### PR DESCRIPTION
I've built this PR merged into cosmic: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/tracking-repo-build/18/

The final result of the build is a failure, but for tother reasons than what I did here.

The result of this PR is a properly printed stack trace in the Marvin logs.
This:
![goodstacktrace](https://cloud.githubusercontent.com/assets/4670993/13913172/9c986e64-ef44-11e5-9652-d633b5398a9a.png)

Instead of this:
![badstacktrace](https://cloud.githubusercontent.com/assets/4670993/13913185/af5ab872-ef44-11e5-9dd8-bd4dd049a935.png)
