### PR TITLE
Update version of parent module of development modules...

### DIFF
--- a/developer/pom.xml
+++ b/developer/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic-core</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic-core</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/tools/apidoc/pom.xml
+++ b/tools/apidoc/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/tools/marvin/pom.xml
+++ b/tools/marvin/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cloud-tools</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic-core</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>5.0.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <build>


### PR DESCRIPTION
…to 5.0.0.1-SNAPSHOT

These modules were missed during the release because they are only activated with the developer profile.
