### PR TITLE
Fix rVPC multi tiers test

### DIFF
--- a/test/integration/smoke/test_vpc_redundant.py
+++ b/test/integration/smoke/test_vpc_redundant.py
@@ -340,34 +340,23 @@ class TestVPCRedundancy(cloudstackTestCase):
                 )
                 host = hosts[0]
 
-                if self.hypervisor.lower() in ('vmware'):
-                        result = str(get_process_status(
-                            self.apiclient.connection.mgtSvr,
-                            22,
-                            self.apiclient.connection.user,
-                            self.apiclient.connection.passwd,
-                            router.linklocalip,
-                            "sh /opt/cloud/bin/checkrouter.sh ",
-                            hypervisor=self.hypervisor
-                        ))
-                else:
-                    try:
-                        host.user, host.passwd = get_host_credentials(
-                            self.config, host.ipaddress)
-                        result = str(get_process_status(
-                            host.ipaddress,
-                            22,
-                            host.user,
-                            host.passwd,
-                            router.linklocalip,
-                            "sh /opt/cloud/bin/checkrouter.sh "
-                        ))
+                try:
+                    host.user, host.passwd = get_host_credentials(
+                        self.config, host.ipaddress)
+                    result = str(get_process_status(
+                        host.ipaddress,
+                        22,
+                        host.user,
+                        host.passwd,
+                        router.linklocalip,
+                        "sh /opt/cloud/bin/checkrouter.sh "
+                    ))
 
-                    except KeyError:
-                        self.skipTest(
-                            "Marvin configuration has no host credentials to\
-                                    check router services")
-            
+                except KeyError:
+                    self.skipTest(
+                        "Marvin configuration has no host credentials to\
+                                check router services")
+
                 if result.count(status_to_check) == 1:
                     cnts[vals.index(status_to_check)] += 1
 

--- a/test/integration/smoke/test_vpc_redundant.py
+++ b/test/integration/smoke/test_vpc_redundant.py
@@ -372,7 +372,7 @@ class TestVPCRedundancy(cloudstackTestCase):
                     cnts[vals.index(status_to_check)] += 1
 
         if cnts[vals.index(status_to_check)] != expected_count:
-            self.fail("Expected '%s' routers at state '%s', but found '%s'!" % (expected_count, status_to_check, cnts[vals.index(status_to_check)]))
+            self.fail("Expected '%s' router[s] at state '%s', but found '%s'!" % (expected_count, status_to_check, cnts[vals.index(status_to_check)]))
 
     def stop_router(self, router):
         self.logger.debug('Stopping router %s' % router.id)
@@ -630,13 +630,13 @@ class TestVPCRedundancy(cloudstackTestCase):
 
     @attr(tags=["advanced", "intervlan"], required_hardware="true")
     def test_05_rvpc_multi_tiers(self):
-        """ Create a redundant VPC with 1 Tier, 1 VM, 1 ACL, 1 PF and test Network GC Nics"""
-        self.logger.debug("Starting test_04_rvpc_network_garbage_collector_nics")
+        """ Create a redundant VPC with 3 Tiers, 3 VMs, 3 PF rules"""
+        self.logger.debug("Starting test_05_rvpc_multi_tiers")
         self.query_routers()
 
-        network = self.create_network(self.services["network_offering"], "10.1.1.1", nr_vms=1, mark_net_cleanup=False)
+        self.networks.append(self.create_network(self.services["network_offering"], "10.1.1.1", nr_vms=1, mark_net_cleanup=False))
+        network = self.create_network(self.services["network_offering_no_lb"], "10.1.2.1", nr_vms=1)
         self.networks.append(network)
-        self.networks.append(self.create_network(self.services["network_offering_no_lb"], "10.1.2.1", nr_vms=1))
         self.networks.append(self.create_network(self.services["network_offering_no_lb"], "10.1.3.1", nr_vms=1))
         
         self.check_routers_state()


### PR DESCRIPTION
Before checking the Master router, we are now sleeping 5 seconds because since we are removing the first tier (NIC) the VRRP will have to reconfigure the interface it uses. Due to the configuration changes, it will start a new election and it might take up to 4 seconds, because each router has an advertisement interval of 2 seconds.

In the 2nd check, we have to sleep 2 seconds (adv interval) because removing an interface will trigger VRRP.

In my opinion, It has to be fixed because an interface not configured on keepalived should not do such a thing. Will create a separate PR to cover that.
