### PR TITLE
Guest network RVR is on eth2

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -27,7 +27,7 @@ import shutil
 from netaddr import *
 from pprint import pprint
 
-PUBLIC_INTERFACES = {"router" : "eth0", "vpcrouter" : "eth1"}
+PUBLIC_INTERFACES = {"router" : "eth2", "vpcrouter" : "eth1"}
 
 STATE_COMMANDS = {"router" : "ip addr | grep eth0 | grep inet | wc -l | xargs bash -c  'if [ $0 == 2 ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'",
                   "vpcrouter" : "ip addr | grep eth1 | grep state | awk '{print $9;}' | xargs bash -c 'if [ $0 == \"UP\" ]; then echo \"MASTER\"; else echo \"BACKUP\"; fi'"}


### PR DESCRIPTION
```
[root@cs1 smoke]# cat /tmp//MarvinLogs/test_routers_network_ops_W7IGSZ/results.txt
Test redundant router internals ... === TestName: test_01_isolate_network_FW_PF_default_routes_egress_true | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_02_isolate_network_FW_PF_default_routes_egress_false | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_01_RVR_Network_FW_PF_SSH_default_routes_egress_true | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_02_RVR_Network_FW_PF_SSH_default_routes_egress_false | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_03_RVR_Network_check_router_state | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 5 tests in 2280.219s

OK
```
