### PR TITLE
Make passwd server work reliable on redundant VPCs

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -523,9 +523,8 @@ class CsIP:
             app.setup()
 
         cmdline = self.config.cmdline()
-        # If redundant then this is dealt with by the master backup functions
-        if self.get_type() in ["guest"] and not cmdline.is_redundant():
-            pwdsvc = CsPasswdSvc(self.address['public_ip']).start()
+        if self.get_type() in ["guest"]:
+            CsPasswdSvc(self.address['public_ip']).start()
 
         if self.get_type() == "public" and self.config.is_vpc():
             if self.address["source_nat"]:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -243,8 +243,8 @@ class CsRedundant(object):
 
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
-            CsPasswdSvc(interface.get_gateway()).stop()
-            CsPasswdSvc(interface.get_ip()).stop()
+            CsPasswdSvc(interface.get_gateway()).restart()
+            CsPasswdSvc(interface.get_ip()).restart()
 
         self.cl.set_fault_state()
         self.cl.save()
@@ -280,8 +280,8 @@ class CsRedundant(object):
 
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
-            CsPasswdSvc(interface.get_gateway()).stop()
-            CsPasswdSvc(interface.get_ip()).stop()
+            CsPasswdSvc(interface.get_gateway()).restart()
+            CsPasswdSvc(interface.get_ip()).restart()
         CsHelper.service("dnsmasq", "stop")
 
         self.cl.set_master_state(False)


### PR DESCRIPTION
Since `cloud-init` requests the password from the DHCP server that gave it its ip address, we need to make sure it runs on both. This fixes #93 

Also, refactored `test_password_server.py` to support VPC networks. It now tests:
- single VPC
- redundant VPC
- isolated network

Test results on current master (shows it was broken on redundant VPCs):

```
test_01_vpc_password_service_single_vpc (integration.smoke.test_password_server_vpc.TestPasswordService) ... === TestName: test_01_vpc_password_service_single_vpc | Status : SUCCESS ===
ok
test_02_vpc_password_service_redundant_vpc (integration.smoke.test_password_server_vpc.TestPasswordService) ... === TestName: test_02_vpc_password_service_redundant_vpc | Status : FAILED ===
FAIL
test_03_password_service_isolated (integration.smoke.test_password_server_vpc.TestPasswordService) ... === TestName: test_03_password_service_isolated | Status : SUCCESS ===
ok
```

Results on this PR branch:

```
test_01_vpc_password_service_single_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_01_vpc_password_service_single_vpc | Status : SUCCESS ===
ok
test_02_vpc_password_service_redundant_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_02_vpc_password_service_redundant_vpc | Status : SUCCESS ===
ok
test_03_password_service_isolated (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_03_password_service_isolated | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 2180.210s

OK
```

Ping @miguelaferreira @wilderrodrigues @borisroman 
