### PR TITLE
Make Marvin SSH output pretty (and remove duplicates)

### DIFF
--- a/tools/marvin/marvin/sshClient.py
+++ b/tools/marvin/marvin/sshClient.py
@@ -94,8 +94,8 @@ class SshClient(object):
         else:
             for strOut in output:
                 results.append(strOut.rstrip())
-        self.logger.debug("{Cmd: %s via Host: %s} {returns: %s}" %
-                          (command, str(self.host), results))
+        self.logger.debug("[SSH] Executing command via host %s: %s Output: %s" %
+                          (str(self.host), command, results))
         return results
 
     def createConnection(self):
@@ -110,10 +110,8 @@ class SshClient(object):
         except_msg = ''
         while self.retryCnt >= 0:
             try:
-                self.logger.debug("====Trying SSH Connection: Host:%s User:%s\
-                                   Port:%s RetryCnt:%s===" %
-                                  (self.host, self.user, str(self.port),
-                                   str(self.retryCnt)))
+                self.logger.debug("[SSH] Trying SSH Connection to host %s on port %s as user %s. RetryCount: %s" %
+                                  (self.host, str(self.port), self.user, str(self.retryCnt)))
                 if self.keyPairFiles is None:
                     self.ssh.connect(hostname=self.host,
                                      port=self.port,
@@ -129,7 +127,7 @@ class SshClient(object):
                                      timeout=self.timeout,
                                      look_for_keys=False
                                      )
-                self.logger.debug("===SSH to Host %s port : %s SUCCESSFUL==="
+                self.logger.debug("[SSH] Connection to host %s on port %s is SUCCESSFUL"
                                   % (str(self.host), str(self.port)))
                 ret = SUCCESS
                 break
@@ -179,7 +177,8 @@ class SshClient(object):
         except Exception as e:
             printException(e)
         finally:
-            self.logger.debug(" Host: %s Cmd: %s Output:%s" % (self.host, command, str(ret)))
+            self.logger.debug("[SSH] Connection to host %s on port %s is SUCCESSFUL"
+                              (str(self.host), command, str(ret)))
             return ret
 
     def scp(self, srcFile, destPath):

--- a/tools/marvin/marvin/sshClient.py
+++ b/tools/marvin/marvin/sshClient.py
@@ -33,6 +33,7 @@ import logging
 from marvin.codes import (
     SUCCESS, FAILED, INVALID_INPUT
 )
+import uuid
 
 
 class SshClient(object):
@@ -57,7 +58,7 @@ class SshClient(object):
         self.keyPairFiles = keyPairFiles
         self.ssh = SSHClient()
         self.ssh.set_missing_host_key_policy(AutoAddPolicy())
-        self.logger = logging.getLogger('sshClient')
+        self.logger = logging.getLogger('sshClient.' + str(uuid.uuid4()))
         self.retryCnt = 0
         self.delay = 0
         self.timeout = 3.0


### PR DESCRIPTION
The cause of the duplicates was that multiple calls to `getLogger()` with the same name always return a reference to the same Logger object as documented here: https://docs.python.org/2/library/logging.html

Made it unique for now, if we spend some more time refactoring we could init the SSH class with the right logger object but that can be done later. This was the fastest way to pretty output.

Before:
![pasted image at 2016_04_09 20_21](https://cloud.githubusercontent.com/assets/1630096/14405545/9886f208-fe91-11e5-801e-10e97e762382.png)

After:
![pasted image at 2016_04_09 20_17](https://cloud.githubusercontent.com/assets/1630096/14405548/a48ab760-fe91-11e5-9aa1-dde6bf4c90e5.png)
