### PR TITLE
Fix log and config path for security_group.py

### DIFF
--- a/scripts/vm/network/security_group.py
+++ b/scripts/vm/network/security_group.py
@@ -32,7 +32,7 @@ iptables = Command("iptables")
 bash = Command("/bin/bash")
 ebtables = Command("ebtables")
 driver = "qemu:///system"
-cfo = configFileOps("/etc/cloudstack/agent/agent.properties")
+cfo = configFileOps("/etc/cosmic/agent/agent.properties")
 hyper = cfo.getEntry("hypervisor.type")
 if hyper == "lxc":
     driver = "lxc:///"
@@ -1006,7 +1006,7 @@ def addFWFramework(brname):
         return False
 
 if __name__ == '__main__':
-    logging.basicConfig(filename="/var/log/cloudstack/agent/security_group.log", format="%(asctime)s - %(message)s", level=logging.DEBUG)
+    logging.basicConfig(filename="/var/log/cosmic/agent/security_group.log", format="%(asctime)s - %(message)s", level=logging.DEBUG)
     parser = OptionParser()
     parser.add_option("--vmname", dest="vmName")
     parser.add_option("--vmip", dest="vmIP")


### PR DESCRIPTION
Old Cloudstack references

Error seen:

```
2016-04-12 12:22:37,908 DEBUG [kvm.resource.LibvirtComputingResource] (main:null) Executing: /usr/share/cosmic-agent/scripts/vm/network/security_group.py can_bridge_firewall pubbr0
2016-04-12 12:22:37,986 DEBUG [kvm.resource.LibvirtComputingResource] (main:null) Exit value is 1
2016-04-12 12:22:37,986 DEBUG [kvm.resource.LibvirtComputingResource] (main:null) Traceback (most recent call last):  File "/usr/share/cosmic-agent/scripts/vm/network/security_group
.py", line 1009, in <module>    logging.basicConfig(filename="/var/log/cloudstack/agent/security_group.log", format="%(asctime)s - %(message)s", level=logging.DEBUG)  File "/usr/lib
64/python2.7/logging/__init__.py", line 1529, in basicConfig    hdlr = FileHandler(filename, mode)  File "/usr/lib64/python2.7/logging/__init__.py", line 902, in __init__    StreamH
andler.__init__(self, self._open())  File "/usr/lib64/python2.7/logging/__init__.py", line 925, in _open    stream = open(self.baseFilename, self.mode)IOError: [Errno 2] No such fil
e or directory: '/var/log/cloudstack/agent/security_group.log'
```

After:

```
2016-04-12 12:38:36,284 DEBUG [kvm.resource.LibvirtComputingResource] (main:null) Executing: /usr/share/cosmic-agent/scripts/vm/network/security_group.py can_bridge_firewall pubbr0
2016-04-12 12:38:36,373 DEBUG [kvm.resource.LibvirtComputingResource] (main:null) Execution is successful.
```
