### PR TITLE
Remove reporting section from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,50 +357,6 @@
       </plugins>
     </pluginManagement>
   </build>
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>${cs.findbugs.version}</version>
-        <configuration>
-          <threshold>Low</threshold><!-- High|Normal|Low|Exp|Ignore -->
-          <effort>Default</effort><!-- Min|Default|Max -->
-          <excludeFilterFile>${basedir}/findbugsExcludeFilter.xml</excludeFilterFile>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${cs.javadoc.version}</version>
-        <configuration>
-          <skip>true</skip>
-          <minmemory>128m</minmemory>
-          <maxmemory>1g</maxmemory>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.7</version>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>3.4</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>2.7</version>
-      </plugin>
-    </plugins>
-  </reporting>
   <profiles>
     <profile>
       <id>systemvm</id>


### PR DESCRIPTION
We are not using any of the reports maven generates. Furthermore, during automated release maven will try to build JavaDocs and that breaks the release process.

If we do need any of these reports, we can enable them again.
