### PR TITLE
Speedup iptables by prefetching the variables

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -773,41 +773,46 @@ class CsForwardingRules(CsDataBag):
             self.forward_vr(rule)
 
     def forward_vr(self, rule):
+        #prefetch iptables variables
+        public_fwinterface = self.getDeviceByIp(rule['public_ip'])
+        internal_fwinterface = self.getDeviceByIp(rule['internal_ip'])
+        public_fwports = self.portsToString(rule['public_ports'], ':')
+        internal_fwports = self.portsToString(rule['internal_ports'], '-')
         fw1 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw2 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['internal_ip']),
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw3 = "-A OUTPUT -d %s/32 -p %s -m %s --dport %s -j DNAT --to-destination %s:%s" % \
               (
                 rule['public_ip'],
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
                 rule['internal_ip'],
-                self.portsToString(rule['internal_ports'], '-')
+                internal_fwports
               )
         fw4 = "-A POSTROUTING -j SNAT --to-source %s -s %s -d %s/32 -o %s -p %s -m %s --dport %s" % \
               (
                 self.getGuestIp(),
                 self.getNetworkByIp(rule['internal_ip']),
                 rule['internal_ip'],
-                self.getDeviceByIp(rule['internal_ip']),
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
                 self.portsToString(rule['internal_ports'], ':')
@@ -815,24 +820,24 @@ class CsForwardingRules(CsDataBag):
         fw5 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -j MARK --set-xmark %s/0xffffffff" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
-                hex(int(self.getDeviceByIp(rule['public_ip'])[3:]))
+                public_fwports,
+                hex(int(public_fwinterface[3:]))
               )
         fw6 = "-A PREROUTING -d %s/32 -i %s -p %s -m %s --dport %s -m state --state NEW -j CONNMARK --save-mark --nfmask 0xffffffff --ctmask 0xffffffff" % \
               (
                 rule['public_ip'],
-                self.getDeviceByIp(rule['public_ip']),
+                public_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
-                self.portsToString(rule['public_ports'], ':'),
+                public_fwports,
               )
         fw7 = "-A FORWARD -i %s -o %s -p %s -m %s --dport %s -m state --state NEW,ESTABLISHED -j ACCEPT" % \
               (
-                self.getDeviceByIp(rule['public_ip']),
-                self.getDeviceByIp(rule['internal_ip']),
+                public_fwinterface,
+                internal_fwinterface,
                 rule['protocol'],
                 rule['protocol'],
                 self.portsToString(rule['internal_ports'], ':')


### PR DESCRIPTION
Backport of ACS PR 1487 to speedup starting of non-VPC routers.

Test results with hardware:

```
test_01_vpc_password_service_single_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_01_vpc_password_service_single_vpc | Status : SUCCESS ===
ok
test_02_vpc_password_service_redundant_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_02_vpc_password_service_redundant_vpc | Status : SUCCESS ===
ok
test_03_password_service_isolated (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_03_password_service_isolated | Status : SUCCESS ===
ok
Create a redundant VPC with two networks with two VMs in each network ... === TestName: test_01_create_redundant_VPC_2tiers_4VMs_4IPs_4PF_ACL | Status : SUCCESS ===
ok
Create a redundant VPC with two networks with two VMs in each network and check default routes ... === TestName: test_02_redundant_VPC_default_routes | Status : SUCCESS ===
ok
Create a redundant VPC with two networks with two VMs in each network ... === TestName: test_03_create_redundant_VPC_1tier_2VMs_2IPs_2PF_ACL_reboot_routers | Status : SUCCESS ===
ok
Create a redundant VPC with 1 Tier, 1 VM, 1 ACL, 1 PF and test Network GC Nics ... === TestName: test_04_rvpc_network_garbage_collector_nics | Status : FAILED ===
FAIL
Create a redundant VPC with 3 Tiers, 3 VMs, 3 PF rules ... === TestName: test_05_rvpc_multi_tiers | Status : SUCCESS ===
ok
Test iptables default INPUT/FORWARD policy on RouterVM ... === TestName: test_02_routervm_iptables_policies | Status : SUCCESS ===
ok
Test iptables default INPUT/FORWARD policies on VPC router ... === TestName: test_01_single_VPC_iptables_policies | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_01_isolate_network_FW_PF_default_routes_egress_true | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_02_isolate_network_FW_PF_default_routes_egress_false | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_01_RVR_Network_FW_PF_SSH_default_routes_egress_true | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_02_RVR_Network_FW_PF_SSH_default_routes_egress_false | Status : SUCCESS ===
ok
Test redundant router internals ... === TestName: test_03_RVR_Network_check_router_state | Status : SUCCESS ===
ok
Create a VPC with two networks with one VM in each network and test nics after destroy ... === TestName: test_01_VPC_nics_after_destroy | Status : SUCCESS ===
ok
Create a VPC with two networks with one VM in each network and test default routes ... === TestName: test_02_VPC_default_routes | Status : SUCCESS ===
ok
Test to create Load balancing rule with source NAT ... === TestName: test_01_create_lb_rule_src_nat | Status : SUCCESS ===
ok
Test to create Load balancing rule with non source NAT ... === TestName: test_02_create_lb_rule_non_nat | Status : SUCCESS ===
ok
Test for assign & removing load balancing rule ... === TestName: test_assign_and_removal_lb | Status : SUCCESS ===
ok
Test create, assign, remove of an Internal LB with roundrobin http traffic to 3 vm's in a Single VPC ... === TestName: test_01_internallb_roundrobin_1VPC_3VM_HTTP_port80 | Status : SUCCESS ===
ok
Test create, assign, remove of an Internal LB with roundrobin http traffic to 3 vm's in a Redundant VPC ... === TestName: test_02_internallb_roundrobin_1RVPC_3VM_HTTP_port80 | Status : SUCCESS ===
ok
Test to verify access to loadbalancer haproxy admin stats page ... === TestName: test_03_vpc_internallb_haproxy_stats_on_all_interfaces | Status : SUCCESS ===
ok
Test to verify access to loadbalancer haproxy admin stats page ... === TestName: test_04_rvpc_internallb_haproxy_stats_on_all_interfaces | Status : SUCCESS ===
ok
Test SSVM Internals ... === TestName: test_03_ssvm_internals | Status : SUCCESS ===
ok
Test CPVM Internals ... === TestName: test_04_cpvm_internals | Status : SUCCESS ===
ok
Test stop SSVM ... === TestName: test_05_stop_ssvm | Status : SUCCESS ===
ok
Test stop CPVM ... === TestName: test_06_stop_cpvm | Status : SUCCESS ===
ok
Test reboot SSVM ... === TestName: test_07_reboot_ssvm | Status : SUCCESS ===
ok
Test reboot CPVM ... === TestName: test_08_reboot_cpvm | Status : SUCCESS ===
ok
Test destroy SSVM ... === TestName: test_09_destroy_ssvm | Status : SUCCESS ===
ok
Test destroy CPVM ... === TestName: test_10_destroy_cpvm | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across redundant VPCs ... === TestName: test_01_redundant_vpc_site2site_vpn | Status : SUCCESS ===
ok
Test Remote Access VPN in VPC ... === TestName: test_01_vpc_remote_access_vpn | Status : SUCCESS ===
ok
Test Site 2 Site VPN Across VPCs ... === TestName: test_01_vpc_site2site_vpn | Status : SUCCESS ===
ok
test_01_vpc_privategw_acl (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_01_vpc_privategw_acl | Status : SUCCESS ===
ok
test_02_vpc_privategw_static_routes (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_02_vpc_privategw_static_routes | Status : SUCCESS ===
ok
test_03_vpc_privategw_static_routes_restart_vpc_cleanup (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_03_vpc_privategw_static_routes_restart_vpc_cleanup | Status : SUCCESS ===
ok
test_04_rvpc_privategw_static_routes (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_04_rvpc_privategw_static_routes | Status : SUCCESS ===
ok
test_05_rvpc_privategw_check_interface (integration.smoke.test_privategw_acl.TestPrivateGwACL) ... === TestName: test_05_rvpc_privategw_check_interface | Status : SUCCESS ===
ok
Test for port forwarding on source NAT ... === TestName: test_01_port_fwd_on_src_nat | Status : SUCCESS ===
ok
Test for port forwarding on non source NAT ... === TestName: test_02_port_fwd_on_non_src_nat | Status : SUCCESS ===
ok
Test for reboot router ... === TestName: test_reboot_router | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_1_static_nat_rule | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_2_nat_rule | Status : SUCCESS ===
ok
Test for Router rules for network rules on acquired public IP ... === TestName: test_network_rules_acquired_public_ip_3_Load_Balancer_Rule | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 47 tests in 26942.966s

FAILED (failures=1)
```

The only test that failed is `test_04_rvpc_network_garbage_collector_nics` which is on the list of known issues to fix.
