### PR TITLE
Fix/passwd server dnsmasq on master only

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -527,6 +527,9 @@ class CsIP:
         # CsRedundant will handle fail-over.
         if self.get_type() in ["guest"] and (not self.cl.is_redundant() or self.cl.is_master()):
             CsPasswdSvc(self.address['public_ip']).start()
+        elif self.get_type() in ["guest"]:
+            # Or else make sure it's stopped
+            CsPasswdSvc(self.address['public_ip']).stop()
 
         if self.get_type() == "public" and self.config.is_vpc():
             if self.address["source_nat"]:

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsAddress.py
@@ -523,7 +523,9 @@ class CsIP:
             app.setup()
 
         cmdline = self.config.cmdline()
-        if self.get_type() in ["guest"]:
+        # Start passwd server on non-redundant routers and on the master router of redundant pairs
+        # CsRedundant will handle fail-over.
+        if self.get_type() in ["guest"] and (not self.cl.is_redundant() or self.cl.is_master()):
             CsPasswdSvc(self.address['public_ip']).start()
 
         if self.get_type() == "public" and self.config.is_vpc():

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsApp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsApp.py
@@ -74,6 +74,8 @@ class CsPasswdSvc():
 
     def stop(self):
         proc = CsProcess(["Password Service"])
+        pid = proc.grep("passwd_server_ip.py %s" % self.ip)
+        proc.kill(pid)
         pid = proc.grep("passwd_server_ip %s" % self.ip)
         proc.kill(pid)
         pid = proc.grep("8080,reuseaddr,fork,crnl,bind=%s" % self.ip)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsDhcp.py
@@ -54,7 +54,10 @@ class CsDhcp(CsDataBag):
         self.cloud.commit()
 
         # We restart DNSMASQ every time the configure.py is called in order to avoid lease problems.
-        CsHelper.execute2("service dnsmasq restart")
+        # But only do that on the master or else VMs will get leases from the backup resulting in
+        # Cloud-init to get the passwd and other meta-data from the backup as well.
+        if not self.cl.is_redundant() or self.cl.is_master():
+            CsHelper.execute2("service dnsmasq restart")
 
     def configure_server(self):
         # self.conf.addeq("dhcp-hostsfile=%s" % DHCP_HOSTS)

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsRedundant.py
@@ -243,8 +243,7 @@ class CsRedundant(object):
 
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
-            CsPasswdSvc(interface.get_gateway()).restart()
-            CsPasswdSvc(interface.get_ip()).restart()
+            CsPasswdSvc(interface.get_ip()).stop()
 
         self.cl.set_fault_state()
         self.cl.save()
@@ -280,8 +279,7 @@ class CsRedundant(object):
 
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
-            CsPasswdSvc(interface.get_gateway()).restart()
-            CsPasswdSvc(interface.get_ip()).restart()
+            CsPasswdSvc(interface.get_ip()).stop()
         CsHelper.service("dnsmasq", "stop")
 
         self.cl.set_master_state(False)
@@ -337,10 +335,9 @@ class CsRedundant(object):
         CsHelper.service("xl2tpd", "restart")
         interfaces = [interface for interface in self.address.get_interfaces() if interface.needs_vrrp()]
         for interface in interfaces:
-            # Listen on gateway and local ip address, as cloud-init uses the 'dhcp-server-identifier' address,
+            # Listen on local ip address, as cloud-init uses the 'dhcp-server-identifier' address,
             #  which unfortunately is not the gateway address.
-            CsPasswdSvc(interface.get_gateway()).restart()
-            CsPasswdSvc(interface.get_ip()).restart()
+            CsPasswdSvc(interface.get_ip()).start()
 
         CsHelper.service("dnsmasq", "restart")
         self.cl.set_master_state(True)


### PR DESCRIPTION
This PR makes sure the `dnsmasq` and `passwd server` processes only run on the master router. I altered the code and also improved the integration test for it.

Tests are running here: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0020-tracking-repo-build/244/

Manual run for the adjusted test:

```
test_01_vpc_password_service_single_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_01_vpc_password_service_single_vpc | Status : SUCCESS ===
ok
test_02_vpc_password_service_redundant_vpc (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_02_vpc_password_service_redundant_vpc | Status : SUCCESS ===
ok
test_03_password_service_isolated (integration.smoke.test_password_server.TestPasswordService) ... === TestName: test_03_password_service_isolated | Status : SUCCESS ===
ok

----------------------------------------------------------------------
Ran 3 tests in 2214.197s

OK

```
