### PR TITLE
Use service offering details to point to right hypervisor

### DIFF
--- a/server/src/main/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
+++ b/server/src/main/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinition.java
@@ -174,6 +174,8 @@ public class VpcRouterDeploymentDefinition extends RouterDeploymentDefinition {
 
             if (router != null) {
                 routers.add(router);
+            } else {
+                logger.error("We didn't get any routers returned, probably the deployment failed.");
             }
         }
     }


### PR DESCRIPTION
As detailed in issue #123, we were unable to run systemvm routers on multiple hypervisor types by selecting an appropriate offering. The solution this PR implements is to use the `service offering details` and look for the value of `hypervisor` and then deploy on that one.

When no `hypervisor` key is found, the previous behaviour is used (loop hypervisors on alphabetical order and use the first one). In our case, that means in a KVM and XenServer mixed zone, routers can only be started on KVM unless we specify global setting `default.systemvm.hypervisor` and point it to XenServer, in which case the behaviour is reversed and it doesn't work on KVM.

Setting the  `service offering details` is a clean and easy solution, should someone want to use it.

More details:

These are the service offerings:

```
MariaDB [cloud]> select id,host_tag from service_offering where vm_type="domainrouter";
+----+---------------+
| id | host_tag      |
+----+---------------+
| 17 | mcc-kvm       |
| 18 | systemvm-kvm  |
| 19 | mcc-xen       |
| 20 | systemvm-xen  |
+----+---------------+
6 rows in set (0.01 sec)
```

I set the corresponding key/value pairs like this (API):

```
(nuc-bubble) 🐵 > add resourcedetail resourceid=a5b77a00-0896-45f2-a9a0-d254e8ff8f1d resourcetype=serviceoffering details[0].key=hypervisor details[0].value=KVM

accountid = 16ced9cf-0d42-11e6-930f-5254001daa61
cmd = org.apache.cloudstack.api.command.user.volume.AddResourceDetailCmd
created = 2016-04-29T13:33:57+0000
jobid = 53625a14-c21f-4f75-b8f4-53ae9672352e
jobprocstatus = 0
jobresult:
success = True
jobresultcode = 0
jobresulttype = object
jobstatus = 1
userid = 16cef1cf-0d42-11e6-930f-5254001daa61
```

Listing the details:

```
(nuc-bubble) 🐵 > list serviceofferings issystem=true filter=name,serviceofferingdetails
count = 4
serviceoffering:
+----------------------------------------------------------+-------------------------------+
|                           name                           |     serviceofferingdetails    |
+----------------------------------------------------------+-------------------------------+
|           Xen-SBP-vRouter-SBP1-256MB-2vCPU               | {u'hypervisor': u'XenServer'} |
|             Xen-SBP-vRouter-256MB-2vCPU                  | {u'hypervisor': u'XenServer'} |
|             KVM-SBP-vRouter-SBP1-256MB-2vCPU             |    {u'hypervisor': u'KVM'}    |
|               KVM-SBP-vRouter-256MB-2vCPU                |    {u'hypervisor': u'KVM'}    |
+----------------------------------------------------------+-------------------------------+
```

In the DB it looks likt this:

```
MariaDB [cloud]> select * from service_offering_details;
+----+---------------------+------------+-----------+---------+
| id | service_offering_id | name       | value     | display |
+----+---------------------+------------+-----------+---------+
|  1 |                  19 | hypervisor | XenServer |       1 |
|  4 |                  17 | hypervisor | KVM       |       1 |
|  5 |                  18 | hypervisor | KVM       |       1 |
|  6 |                  20 | hypervisor | XenServer |       1 |
+----+---------------------+------------+-----------+---------+
4 rows in set (0.00 sec)
```

Then created 4 types of VPC: single/redundant on both KVM/XenServer (in a single zone):

```
(nuc-bubble) 🐵 > list vpcs filter=name
count = 4
vpc:
+----------+
|   name   |
+----------+
| red-kvm  |
| red-xen  |
| testxen1 |
| testkvm1 |
+----------+
```

The routers run on the hypervisors:

```
(nuc-bubble) 🐵 > list routers filter=name,hostname,hypervisor
count = 6
router:
+------------+----------+---------+
| hypervisor | hostname |   name  |
+------------+----------+---------+
| XenServer  |   xen2   | r-16-VM |
| XenServer  |   xen2   | r-59-VM |
|    KVM     |   kvm1   |  r-3-VM |
| XenServer  |   xen2   | r-57-VM |
|    KVM     |   kvm1   | r-67-VM |
|    KVM     |   kvm1   | r-66-VM |
+------------+----------+---------+
```

Here you see the link to the actual VPC/router:

```
(nuc-bubble) 🐵 > list vpcs filter=name,id
count = 4
vpc:
+--------------------------------------+----------+
|                  id                  |   name   |
+--------------------------------------+----------+
| 581eddc3-5c36-4520-9921-6008da77776c | red-kvm  |
| ebdd48e3-f186-4946-82a6-c6ac9b46f98d | red-xen  |
| fa697073-a648-4118-8194-0653c23867fd | testxen1 |
| 95c9b881-d1b0-4e63-ad10-1ca85fe71340 | testkvm1 |
+--------------------------------------+----------+
(nuc-bubble) 🐵 > list routers vpcid=581eddc3-5c36-4520-9921-6008da77776c filter=name
count = 2
router:
+---------+
|   name  |
+---------+
| r-67-VM |
| r-66-VM |
+---------+
(nuc-bubble) 🐵 > list routers  filter=name vpcid=ebdd48e3-f186-4946-82a6-c6ac9b46f98d 
count = 2
router:
+---------+
|   name  |
+---------+
| r-59-VM |
| r-57-VM |
+---------+
(nuc-bubble) 🐵 > list routers  filter=name vpcid=fa697073-a648-4118-8194-0653c23867fd 
count = 1
router:
+---------+
|   name  |
+---------+
| r-16-VM |
+---------+
(nuc-bubble) 🐵 > list routers  filter=name vpcid=95c9b881-d1b0-4e63-ad10-1ca85fe71340 
count = 1
router:
+--------+
|  name  |
+--------+
| r-3-VM |
+--------+
```

Will schedule an integration test run and post the results.

This fixes #123 
