### PR TITLE
Fix smoke/test_vpc_redundant

### DIFF
--- a/test/integration/smoke/test_vpc_redundant.py
+++ b/test/integration/smoke/test_vpc_redundant.py
@@ -659,7 +659,6 @@ class TestVPCRedundancy(cloudstackTestCase):
 
         time.sleep(total_sleep * 3)
 
-        self.check_routers_state(status_to_check="MASTER")
         self.check_routers_interface(interface_to_check="eth2", expected_exists=False)
         self.start_vm()
         self.check_routers_state(status_to_check="MASTER")


### PR DESCRIPTION
When no tiers are connected, keepalived becomes inconsistent.

Integration tests: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0002-tracking-repo-branch-build/41
