### PR TITLE
Remove check on tags when switching service offerings

### DIFF
--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.agent.api.AttachOrDettachConfigDriveCommand;
+import com.cloud.dc.*;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
@@ -94,7 +95,6 @@ import com.cloud.agent.api.StopAnswer;
 import com.cloud.agent.api.StopCommand;
 import com.cloud.agent.api.UnPlugNicAnswer;
 import com.cloud.agent.api.UnPlugNicCommand;
-import com.cloud.agent.api.UnregisterVMCommand;
 import com.cloud.agent.api.to.DiskTO;
 import com.cloud.agent.api.to.GPUDeviceTO;
 import com.cloud.agent.api.to.NicTO;
@@ -103,12 +103,6 @@ import com.cloud.agent.manager.Commands;
 import com.cloud.agent.manager.allocator.HostAllocator;
 import com.cloud.alert.AlertManager;
 import com.cloud.capacity.CapacityManager;
-import com.cloud.dc.ClusterDetailsDao;
-import com.cloud.dc.ClusterDetailsVO;
-import com.cloud.dc.DataCenter;
-import com.cloud.dc.DataCenterVO;
-import com.cloud.dc.HostPodVO;
-import com.cloud.dc.Pod;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.dc.dao.DataCenterDao;
 import com.cloud.dc.dao.HostPodDao;
@@ -176,7 +170,6 @@ import com.cloud.utils.Journal;
 import com.cloud.utils.Pair;
 import com.cloud.utils.Predicate;
 import com.cloud.utils.ReflectionUse;
-import com.cloud.utils.StringUtils;
 import com.cloud.utils.Ternary;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.concurrency.NamedThreadFactory;
@@ -908,17 +901,7 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                             if (planToDeploy != null && planToDeploy.getDataCenterId() != 0) {
                                 final Long clusterIdSpecified = planToDeploy.getClusterId();
                                 if (clusterIdSpecified != null && rootVolClusterId != null) {
-                                    if (rootVolClusterId.longValue() != clusterIdSpecified.longValue()) {
-                                        // cannot satisfy the plan passed in to the
-                                        // planner
-                                        if (s_logger.isDebugEnabled()) {
-                                            s_logger.debug("Cannot satisfy the deployment plan passed in since the ready Root volume is in different cluster. volume's cluster: " +
-                                                    rootVolClusterId + ", cluster specified: " + clusterIdSpecified);
-                                        }
-                                        throw new ResourceUnavailableException(
-                                                "Root volume is ready in different cluster, Deployment plan provided cannot be satisfied, unable to create a deployment for " +
-                                                        vm, Cluster.class, clusterIdSpecified);
-                                    }
+                                    checkIfPlanIsDeployable(vm, rootVolClusterId, clusterIdSpecified);
                                 }
                                 plan =
                                         new DataCenterDeployment(planToDeploy.getDataCenterId(), planToDeploy.getPodId(), planToDeploy.getClusterId(),
@@ -1153,6 +1136,23 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         if (startedVm == null) {
             throw new CloudRuntimeException("Unable to start instance '" + vm.getHostName() + "' (" + vm.getUuid() + "), see management server log for details");
+        }
+    }
+
+    private void checkIfPlanIsDeployable(final VMInstanceVO vm, final Long rootVolClusterId, final Long clusterIdSpecified) throws ResourceUnavailableException {
+        if (rootVolClusterId.longValue() != clusterIdSpecified.longValue()) {
+            // cannot satisfy the plan passed in to the planner
+            ClusterVO volumeCluster = _clusterDao.findById(rootVolClusterId);
+            ClusterVO vmCluster = _clusterDao.findById(clusterIdSpecified);
+
+            String errorMsg;
+            errorMsg = String.format("Root volume is ready in cluster '%s' while VM is to be started in cluster '%s'. Make sure these match. Unable to create a deployment for %s",
+                    volumeCluster.getName(), vmCluster.getName(), vm);
+
+            if (s_logger.isDebugEnabled()) {
+                s_logger.debug(errorMsg);
+            }
+            throw new ResourceUnavailableException(errorMsg, Cluster.class, clusterIdSpecified);
         }
     }
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -2856,15 +2856,6 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
 
         final ServiceOfferingVO currentServiceOffering = _offeringDao.findByIdIncludingRemoved(vmInstance.getId(), vmInstance.getServiceOfferingId());
 
-        // Check that the service offering being upgraded to has the same Guest IP type as the VM's current service offering
-        // NOTE: With the new network refactoring in 2.2, we shouldn't need the check for same guest IP type anymore.
-        /*
-         * if (!currentServiceOffering.getGuestIpType().equals(newServiceOffering.getGuestIpType())) { String errorMsg =
-         * "The service offering being upgraded to has a guest IP type: " + newServiceOffering.getGuestIpType(); errorMsg +=
-         * ". Please select a service offering with the same guest IP type as the VM's current service offering (" +
-         * currentServiceOffering.getGuestIpType() + ")."; throw new InvalidParameterValueException(errorMsg); }
-         */
-
         // Check that the service offering being upgraded to has the same storage pool preference as the VM's current service
         // offering
         if (currentServiceOffering.getUseLocalStorage() != newServiceOffering.getUseLocalStorage()) {
@@ -2882,14 +2873,6 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
         if (!isVirtualMachineUpgradable(vmInstance, newServiceOffering)) {
             throw new InvalidParameterValueException("Unable to upgrade virtual machine, not enough resources available " + "for an offering of " +
                     newServiceOffering.getCpu() + " cpu(s) at " + newServiceOffering.getSpeed() + " Mhz, and " + newServiceOffering.getRamSize() + " MB of memory");
-        }
-
-        // Check that the service offering being upgraded to has storage tags subset of the current service offering storage tags, since volume is not migrated.
-        final List<String> currentTags = StringUtils.csvTagsToList(currentServiceOffering.getTags());
-        final List<String> newTags = StringUtils.csvTagsToList(newServiceOffering.getTags());
-        if (!currentTags.containsAll(newTags)) {
-            throw new InvalidParameterValueException("Unable to upgrade virtual machine; the new service offering " + " should have tags as subset of " +
-                    "current service offering tags. Current service offering tags: " + currentTags + "; " + "new service " + "offering tags: " + newTags);
         }
     }
 

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -38,7 +38,12 @@ import javax.inject.Inject;
 import javax.naming.ConfigurationException;
 
 import com.cloud.agent.api.AttachOrDettachConfigDriveCommand;
-import com.cloud.dc.*;
+import com.cloud.dc.ClusterDetailsDao;
+import com.cloud.dc.ClusterDetailsVO;
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.HostPodVO;
+import com.cloud.dc.Pod;
 import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;

--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/VolumeOrchestrator.java
@@ -913,8 +913,8 @@ public class VolumeOrchestrator extends ManagerBase implements VolumeOrchestrati
         try {
             VolumeApiResult result = future.get();
             if (result.isFailed()) {
-                s_logger.error("Migrate volume failed:" + result.getResult());
-                throw new StorageUnavailableException("Migrate volume failed: " + result.getResult(), destPool.getId());
+                s_logger.error("Migrate volume failed. Error received from hypervisor:" + result.getResult());
+                throw new StorageUnavailableException("Migrate volume failed. Error received from hypervisor: " + result.getResult(), destPool.getId());
             } else {
                 // update the volumeId for snapshots on secondary
                 if (!_snapshotDao.listByVolumeId(vol.getId()).isEmpty()) {

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2622,23 +2622,6 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
     return _diskOfferingJoinDao.searchAndCount(sc, searchFilter);
   }
 
-  private List<ServiceOfferingJoinVO> filterOfferingsOnCurrentTags(List<ServiceOfferingJoinVO> offerings, ServiceOfferingVO currentVmOffering){
-    if(currentVmOffering == null) {
-      return offerings;
-    }
-    final List<String> currentTagsList = StringUtils.csvTagsToList(currentVmOffering.getTags());
-
-    // New offerings should be a subset of existing storage tags. Discard offerings who are not.
-    final List<ServiceOfferingJoinVO> filteredOfferings = new ArrayList<>();
-    for (final ServiceOfferingJoinVO offering : offerings){
-      final List<String> tags = StringUtils.csvTagsToList(offering.getTags());
-      if(currentTagsList.containsAll(tags)){
-        filteredOfferings.add(offering);
-      }
-    }
-    return filteredOfferings;
-  }
-
   @Override
   public ListResponse<ServiceOfferingResponse> searchForServiceOfferings(ListServiceOfferingsCmd cmd) {
     final Pair<List<ServiceOfferingJoinVO>, Integer> result = searchForServiceOfferingsInternal(cmd);
@@ -2794,10 +2777,7 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
     }
 
     final Pair<List<ServiceOfferingJoinVO>, Integer> result = _srvOfferingJoinDao.searchAndCount(sc, searchFilter);
-
-    //Couldn't figure out a smart way to filter offerings based on tags in sql so doing it in Java.
-    final List<ServiceOfferingJoinVO> filteredOfferings = filterOfferingsOnCurrentTags(result.first(), currentVmOffering);
-    return new Pair<>(filteredOfferings, result.second());
+    return result;
   }
 
   @Override

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1981,15 +1981,15 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     try {
       final VolumeApiResult result = future.get();
       if (result.isFailed()) {
-        s_logger.debug("migrate volume failed:" + result.getResult());
-        throw new StorageUnavailableException("Migrate volume failed: " + result.getResult(), destPool.getId());
+        s_logger.debug("Live migrate volume failed:" + result.getResult());
+        throw new StorageUnavailableException("Live migrate volume failed: " + result.getResult(), destPool.getId());
       }
       return result.getVolume();
     } catch (final InterruptedException e) {
-      s_logger.debug("migrate volume failed", e);
+      s_logger.debug("Live migrate volume failed", e);
       throw new CloudRuntimeException(e.getMessage());
     } catch (final ExecutionException e) {
-      s_logger.debug("migrate volume failed", e);
+      s_logger.debug("Live migrate volume failed", e);
       throw new CloudRuntimeException(e.getMessage());
     }
   }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1896,7 +1896,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
         // to make sure that the destination storage pool is in the same cluster as the vm.
         if (liveMigrateVolume && destPool.getClusterId() != null && srcClusterId != null) {
           if (!srcClusterId.equals(destPool.getClusterId())) {
-            throw new InvalidParameterValueException("Cannot migrate a volume of a virtual machine to a storage pool in a different cluster");
+            throw new InvalidParameterValueException("Cannot live migrate a volume of a virtual machine to a storage pool in a different cluster. Please stop VM and try again.");
           }
         }
       }


### PR DESCRIPTION
When changing service offering, a check was in place that made sure the new service offering had the same tags as the previous one. That greatly limits the possibilities to change offerings, and we found ourselves using the `SQL API` to work around this. Hence, I removed the check so we can use the API/UI instead of hacking the DB.

The procedure to move to a new offering on a new storage pool:
- stop vm
- change offering
- migrate volume(s) <== there is a CloudStackOps script for this
- start VM on new cluster

When the offering doesn't match the volume (in case one step was done instead of two) an error is thrown. I also improved that error messages. 

From this:
![screen shot 2016-05-14 at 22 45 53](https://cloud.githubusercontent.com/assets/1630096/15297563/17cdb184-1b9b-11e6-94e7-4343c9d99107.png)

To this:
![screen shot 2016-05-15 at 21 44 39](https://cloud.githubusercontent.com/assets/1630096/15297565/1f23bdc0-1b9b-11e6-9807-16a06b45ff93.png)

I tested this in the bubble with two clusters, each with its own tags. Then created compute offerings to point to these clusters. Started two VMs, one on each offering. After that shut one VM, changed offering to the other one, migrated its volume to the other cluster and started it, which worked. All from the UI/API.

@borisroman There was duplicated code in both classes that did the same check. I improved the check and extracted it to a method. Would like to know if there's a way to use one method and have both access it so we prevent duplicated code?
