### PR TITLE
Also list volumes of type system for the root user

### DIFF
--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -1790,7 +1790,12 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
       sc.setParameters("display", display);
     }
 
+    // normal users and domain admins cannot see volumes of type system
     sc.setParameters("systemUse", 1);
+    // root admins can see them
+    if (caller.getType() == Account.ACCOUNT_TYPE_ADMIN) {
+      sc.setParameters("systemUse", -1);
+    }
 
     if (tags != null && !tags.isEmpty()) {
       final SearchCriteria<VolumeJoinVO> tagSc = _volumeJoinDao.createSearchCriteria();
@@ -1828,8 +1833,8 @@ public class QueryManagerImpl extends ManagerBase implements QueryService, Confi
       sc.setParameters("storageId", storageId);
     }
 
-    // Don't return DomR and ConsoleProxy volumes
-    sc.setParameters("type", VirtualMachine.Type.ConsoleProxy, VirtualMachine.Type.SecondaryStorageVm, VirtualMachine.Type.DomainRouter);
+    // The only thing we don't need is UserBareMetal volumes as those are fake anyway
+    sc.setParameters("type", VirtualMachine.Type.UserBareMetal);
 
     // Only return volumes that are not destroyed
     sc.setParameters("state", Volume.State.Destroy);


### PR DESCRIPTION
Root admins will also see the volumes belonging to system vms:
![list-all-volumes-ui1](https://cloud.githubusercontent.com/assets/1630096/15318852/56a00230-1c28-11e6-845e-f286af2c1627.png)

Domain admins and ordinary users won't see this.

This allows for migration of offline systemvm volumes. This way you can move a systemvm to another cluster. There used to be a hack in CloudStackOps that would query the DB for the volume Uuid but it's better and easier for the API to return it.

Example of router migrate fully via API (also works in UI):
![migrate-router-via-api](https://cloud.githubusercontent.com/assets/1630096/15318913/958292d8-1c28-11e6-8026-7e38abdec4ee.png)
