### PR TITLE
Add pluggableAPIAuthenticatorsRegistry bean.

### DIFF
--- a/nucleo/src/main/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
+++ b/nucleo/src/main/resources/META-INF/cloudstack/core/spring-core-registry-core-context.xml
@@ -36,6 +36,12 @@
         <property name="orderConfigDefault" value="PBKDF2,SHA256SALT,LDAP,PLAINTEXT" />
     </bean>
 
+    <bean id="pluggableAPIAuthenticatorsRegistry"
+          class="org.apache.cloudstack.spring.lifecycle.registry.ExtensionRegistry">
+        <property name="orderConfigKey" value="pluggableApi.authenticators.order" />
+        <property name="excludeKey" value="pluggableApi.authenticators.exclude" />
+    </bean>
+
     <bean id="userPasswordEncodersRegistry"
         class="org.apache.cloudstack.spring.lifecycle.registry.ExtensionRegistry">
         <property name="orderConfigKey" value="user.password.encoders.order" />


### PR DESCRIPTION
During the removal of SAML2 this was removed as well. It is still being dependent on.
