### PR TITLE
Load default CAs into custom Keystore

### DIFF
--- a/systemvm/scripts/config_ssl.sh
+++ b/systemvm/scripts/config_ssl.sh
@@ -18,7 +18,7 @@
 
 
 
- 
+
 help() {
    printf " -c use customized key/cert\n"
    printf " -k path of private key\n"
@@ -123,6 +123,8 @@ customCACert=
 publicIp=
 hostName=
 keyStore=$(dirname $0)/certs/realhostip.keystore
+defaultJavaKeyStoreFile=/etc/ssl/certs/java/cacerts
+defaultJavaKeyStorePass=changeit
 aliasName="CPVMCertificate"
 storepass="vmops.com"
 while getopts 'i:h:k:p:t:u:c' OPTION
@@ -167,7 +169,7 @@ then
   fi
   if [ ! -f "$customPrivKey" ]
   then
-     printf "priviate key file is not exist\n"
+     printf "private key file is not exist\n"
      exit 2
   fi
 
@@ -204,6 +206,7 @@ if [ -f "$customCACert" ]
 then
   keytool -delete -alias $aliasName -keystore $keyStore -storepass $storepass -noprompt
   keytool -import -alias $aliasName -keystore $keyStore -storepass $storepass -noprompt -file $customCACert
+  keytool -importkeystore -srckeystore $defaultJavaKeyStoreFile -destkeystore $keyStore -srcstorepass $defaultJavaKeyStorePass -deststorepass $storepass
 fi
 
 if [ -d /etc/apache2 ]


### PR DESCRIPTION
When using a custom SSL certificate, a separate keystore was loaded that only included the custom cert and not the default CAs. As a result, no other certificates could be verified any more. The solution is to load the system CAs into the custom keystore.

While I was investigating, also someone in ACS community fixed it so that was nice. Backported it.

The only remaining issue I see is that I cannot connect to servers that require TLSv1.2 (https://beta-jenkins.mccc.schubergphilis.com). Need to look into that further and see if it's something on the SSVM or something on the remote server. But let's merge this as with this PR the situation when using a custom cert and when not using a cert are the same.

By the way, for already running environments, we can do this to import the missing certs:

```
defaultJavaKeyStoreFile=/etc/ssl/certs/java/cacerts
defaultJavaKeyStorePass=changeit
keyStore=/usr/local/cloud/systemvm/certs/realhostip.keystore
storepass="vmops.com"

keytool -importkeystore -srckeystore $defaultJavaKeyStoreFile -destkeystore $keyStore -srcstorepass $defaultJavaKeyStorePass -deststorepass $storepass
```

Result:

```
root@s-2-VM:~# keytool -importkeystore -srckeystore $defaultJavaKeyStoreFile -destkeystore $keyStore -srcstorepass $defaultJavaKeyStorePass -deststorepass $storepass
<cut>
Import command completed:  172 entries successfully imported, 0 entries failed or cancelled
```
