### PR TITLE
Expose hypervisor hostname and instance name to the user

### DIFF
--- a/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/UserVmJoinDaoImpl.java
@@ -145,10 +145,10 @@ public class UserVmJoinDaoImpl extends GenericDaoBase<UserVmJoinVO, Long> implem
         userVmResponse.setZoneId(userVm.getDataCenterUuid());
         userVmResponse.setZoneName(userVm.getDataCenterName());
         if (view == ResponseView.Full) {
-            userVmResponse.setInstanceName(userVm.getInstanceName());
             userVmResponse.setHostId(userVm.getHostUuid());
-            userVmResponse.setHostName(userVm.getHostName());
         }
+        userVmResponse.setInstanceName(userVm.getInstanceName());
+        userVmResponse.setHostName(userVm.getHostName());
 
         if (details.contains(VMDetails.all) || details.contains(VMDetails.tmpl)) {
             userVmResponse.setTemplateId(userVm.getTemplateUuid());


### PR DESCRIPTION
This allows end-users to see where their VM is running. Normally these are hidden for cloud users, but on the other hand this gives some insight in how customers are deploying their VMs. The instance-id is much handier to communicate than the UUID that they also see.

As requested by @rtnh 

UI:
![nonroot-hostname-display](https://cloud.githubusercontent.com/assets/1630096/15548459/c402a004-22a8-11e6-8da6-df3936f75ec9.png)

![root-hostname-display](https://cloud.githubusercontent.com/assets/1630096/15548463/c5fae380-22a8-11e6-9988-bd191c6f7269.png)

CloudMonkey:
User now sees hostname and instance-id:
![screen shot 2016-05-25 at 18 43 40](https://cloud.githubusercontent.com/assets/1630096/15548451/b73c25de-22a8-11e6-97e2-c8889406adaa.png)

Root is unchanged:
![screen shot 2016-05-25 at 18 43 25](https://cloud.githubusercontent.com/assets/1630096/15548454/b9374378-22a8-11e6-9159-30ba3bfb86b5.png)
