### PR TITLE
Implement static routes on the VPC level

### DIFF
--- a/api/src/main/java/com/cloud/network/vpc/StaticRoute.java
+++ b/api/src/main/java/com/cloud/network/vpc/StaticRoute.java
@@ -32,11 +32,6 @@ public interface StaticRoute extends ControlledEntity, Identity, InternalIdentit
     /**
      * @return
      */
-    long getVpcGatewayId();
-
-    /**
-     * @return
-     */
     String getCidr();
 
     /**

--- a/api/src/main/java/com/cloud/network/vpc/StaticRoute.java
+++ b/api/src/main/java/com/cloud/network/vpc/StaticRoute.java
@@ -48,4 +48,6 @@ public interface StaticRoute extends ControlledEntity, Identity, InternalIdentit
      * @return
      */
     Long getVpcId();
+
+    String getGwIpAddress();
 }

--- a/api/src/main/java/com/cloud/network/vpc/StaticRouteProfile.java
+++ b/api/src/main/java/com/cloud/network/vpc/StaticRouteProfile.java
@@ -23,7 +23,6 @@ public class StaticRouteProfile implements StaticRoute {
     private String targetCidr;
     private long accountId;
     private long domainId;
-    private long gatewayId;
     private StaticRoute.State state;
     private long vpcId;
     String ipAddress;
@@ -34,7 +33,6 @@ public class StaticRouteProfile implements StaticRoute {
         targetCidr = staticRoute.getCidr();
         accountId = staticRoute.getAccountId();
         domainId = staticRoute.getDomainId();
-        gatewayId = staticRoute.getVpcGatewayId();
         state = staticRoute.getState();
         vpcId = staticRoute.getVpcId();
         ipAddress = staticRoute.getGwIpAddress();
@@ -48,11 +46,6 @@ public class StaticRouteProfile implements StaticRoute {
     @Override
     public long getDomainId() {
         return domainId;
-    }
-
-    @Override
-    public long getVpcGatewayId() {
-        return gatewayId;
     }
 
     @Override

--- a/api/src/main/java/com/cloud/network/vpc/StaticRouteProfile.java
+++ b/api/src/main/java/com/cloud/network/vpc/StaticRouteProfile.java
@@ -26,12 +26,9 @@ public class StaticRouteProfile implements StaticRoute {
     private long gatewayId;
     private StaticRoute.State state;
     private long vpcId;
-    String vlanTag;
-    String gateway;
-    String netmask;
     String ipAddress;
 
-    public StaticRouteProfile(StaticRoute staticRoute, VpcGateway gateway) {
+    public StaticRouteProfile(StaticRoute staticRoute) {
         id = staticRoute.getId();
         uuid = staticRoute.getUuid();
         targetCidr = staticRoute.getCidr();
@@ -40,10 +37,7 @@ public class StaticRouteProfile implements StaticRoute {
         gatewayId = staticRoute.getVpcGatewayId();
         state = staticRoute.getState();
         vpcId = staticRoute.getVpcId();
-        vlanTag = gateway.getBroadcastUri();
-        this.gateway = gateway.getGateway();
-        netmask = gateway.getNetmask();
-        ipAddress = gateway.getIp4Address();
+        ipAddress = staticRoute.getGwIpAddress();
     }
 
     @Override
@@ -86,20 +80,12 @@ public class StaticRouteProfile implements StaticRoute {
         return uuid;
     }
 
-    public String getVlanTag() {
-        return vlanTag;
+    public String getGwIpAddress() {
+        return ipAddress;
     }
 
     public String getIp4Address() {
         return ipAddress;
-    }
-
-    public String getGateway() {
-        return gateway;
-    }
-
-    public String getNetmask() {
-        return netmask;
     }
 
     @Override

--- a/api/src/main/java/com/cloud/network/vpc/VpcService.java
+++ b/api/src/main/java/com/cloud/network/vpc/VpcService.java
@@ -226,7 +226,7 @@ public interface VpcService {
      * @param cidr
      * @return
      */
-    public StaticRoute createStaticRoute(long gatewayId, String cidr) throws NetworkRuleConflictException;
+    public StaticRoute createStaticRoute(long vpcId, String cidr, String gwIpAddress) throws NetworkRuleConflictException;
 
     /**
      * Lists static routes based on parameters passed to the call

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -168,6 +168,7 @@ public class ApiConstants {
     public static final String NETWORK_DOMAIN = "networkdomain";
     public static final String NETMASK = "netmask";
     public static final String NEW_NAME = "newname";
+    public static final String NEXT_HOP = "nexthop";
     public static final String NUM_RETRIES = "numretries";
     public static final String OFFER_HA = "offerha";
     public static final String IS_SYSTEM_OFFERING = "issystem";

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
@@ -50,10 +50,10 @@ public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
                description = "The VPC id we are creating static route for.")
     private Long vpcId;
 
-    @Parameter(name = ApiConstants.CIDR, required = true, type = CommandType.STRING, description = "static route cidr")
+    @Parameter(name = ApiConstants.CIDR, required = true, type = CommandType.STRING, description = "The CIDR to create the static route for")
     private String cidr;
 
-    @Parameter(name = ApiConstants.IP_ADDRESS, type = CommandType.STRING, description = "static route gateway ip address")
+    @Parameter(name = ApiConstants.NEXT_HOP, type = CommandType.STRING, description = "Ip address of the nexthop to route the CIDR to")
     private String gwIpAddress;
 
     @Parameter(name = ApiConstants.GATEWAY_ID,

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/CreateStaticRouteCmd.java
@@ -17,13 +17,11 @@
 package org.apache.cloudstack.api.command.user.vpc;
 
 import com.cloud.event.EventTypes;
-import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.network.vpc.StaticRoute;
 import com.cloud.network.vpc.Vpc;
-import com.cloud.network.vpc.VpcGateway;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiCommandJobType;
 import org.apache.cloudstack.api.ApiConstants;
@@ -53,7 +51,7 @@ public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
     @Parameter(name = ApiConstants.CIDR, required = true, type = CommandType.STRING, description = "static route cidr")
     private String cidr;
 
-    @Parameter(name = ApiConstants.GATEWAY, required = true, type = CommandType.STRING, description = "static route gateway ip address")
+    @Parameter(name = ApiConstants.IP_ADDRESS, required = true, type = CommandType.STRING, description = "static route gateway ip address")
     private String gwIpAddress;
 
     /////////////////////////////////////////////////////
@@ -127,11 +125,7 @@ public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
 
     @Override
     public long getEntityOwnerId() {
-        VpcGateway gateway = _entityMgr.findById(VpcGateway.class, vpcId);
-        if (gateway == null) {
-            throw new InvalidParameterValueException("Invalid gateway id is specified");
-        }
-        return _entityMgr.findById(Vpc.class, gateway.getVpcId()).getAccountId();
+        return _entityMgr.findById(Vpc.class, vpcId).getAccountId();
     }
 
     @Override
@@ -141,11 +135,7 @@ public class CreateStaticRouteCmd extends BaseAsyncCreateCmd {
 
     @Override
     public Long getSyncObjId() {
-        VpcGateway gateway = _entityMgr.findById(VpcGateway.class, vpcId);
-        if (gateway == null) {
-            throw new InvalidParameterValueException("Invalid id is specified for the gateway");
-        }
-        return gateway.getVpcId();
+        return getVpcId();
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
@@ -50,7 +50,7 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.GATEWAY_ID, type = CommandType.UUID, entityType = PrivateGatewayResponse.class, description = "list static routes by gateway id (DEPRECATED!)")
     private Long gatewayId;
 
-    @Parameter(name = ApiConstants.IP_ADDRESS, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by gateway ip address")
+    @Parameter(name = ApiConstants.NEXT_HOP, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by nexthop ip address")
     private String gwIpAddress;
 
     @Parameter(name = ApiConstants.CIDR, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by cidr")

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
@@ -19,6 +19,8 @@ package org.apache.cloudstack.api.command.user.vpc;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.cloud.network.vpc.VpcGateway;
+import com.cloud.utils.net.NetUtils;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseListTaggedResourcesCmd;
@@ -45,6 +47,9 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.VPC_ID, type = CommandType.UUID, entityType = VpcResponse.class, description = "list static routes by vpc id")
     private Long vpcId;
 
+    @Parameter(name = ApiConstants.GATEWAY_ID, type = CommandType.UUID, entityType = PrivateGatewayResponse.class, description = "list static routes by gateway id (DEPRECATED!)")
+    private Long gatewayId;
+
     @Parameter(name = ApiConstants.IP_ADDRESS, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by gateway ip address")
     private String gwIpAddress;
 
@@ -57,6 +62,10 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
 
     public Long getVpcId() {
         return vpcId;
+    }
+
+    public Long getGatewayId() {
+        return gatewayId;
     }
 
     public String getGwIpAddress() {
@@ -81,7 +90,17 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
         ListResponse<StaticRouteResponse> response = new ListResponse<StaticRouteResponse>();
         List<StaticRouteResponse> routeResponses = new ArrayList<StaticRouteResponse>();
 
+        // Compatibility with pre 5.1
+        // If gatewayId was passed, lookup its CIDR and match static routes to it
+        String GatewayCidr = "0.0.0.0/0";
+        if (gatewayId != null) {
+            VpcGateway gateway = _vpcService.getVpcPrivateGateway(gatewayId);
+            GatewayCidr = NetUtils.ipAndNetMaskToCidr(gateway.getGateway(), gateway.getNetmask());
+        }
         for (StaticRoute route : result.first()) {
+            if (! NetUtils.isIpWithtInCidrRange(route.getGwIpAddress(), GatewayCidr)) {
+                continue;
+            }
             StaticRouteResponse ruleData = _responseGenerator.createStaticRouteResponse(route);
             routeResponses.add(ruleData);
         }

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/vpc/ListStaticRoutesCmd.java
@@ -45,8 +45,11 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
     @Parameter(name = ApiConstants.VPC_ID, type = CommandType.UUID, entityType = VpcResponse.class, description = "list static routes by vpc id")
     private Long vpcId;
 
-    @Parameter(name = ApiConstants.GATEWAY_ID, type = CommandType.UUID, entityType = PrivateGatewayResponse.class, description = "list static routes by gateway id")
-    private Long gatewayId;
+    @Parameter(name = ApiConstants.IP_ADDRESS, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by gateway ip address")
+    private String gwIpAddress;
+
+    @Parameter(name = ApiConstants.CIDR, type = CommandType.STRING, entityType = VpcResponse.class, description = "list static routes by cidr")
+    private String cidr;
 
     public Long getId() {
         return id;
@@ -56,8 +59,12 @@ public class ListStaticRoutesCmd extends BaseListTaggedResourcesCmd {
         return vpcId;
     }
 
-    public Long getGatewayId() {
-        return gatewayId;
+    public String getGwIpAddress() {
+        return gwIpAddress;
+    }
+
+    public String getCidr() {
+        return cidr;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
@@ -46,7 +46,7 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
     @Param(description = "VPC gateway the route is created for")
     private String gatewayId;
 
-    @SerializedName(ApiConstants.IP_ADDRESS)
+    @SerializedName(ApiConstants.NEXT_HOP)
     @Param(description = "Gateway ip address the CIDR is routed to")
     private String gwIpAddress;
 

--- a/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
@@ -42,12 +42,12 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
     @Param(description = "VPC the static route belongs to")
     private String vpcId;
 
-    @SerializedName(ApiConstants.GATEWAY_ID)
-    @Param(description = "VPC gateway the route is created for")
-    private String gatewayId;
+    @SerializedName(ApiConstants.IP_ADDRESS)
+    @Param(description = "Gateway ip address the CIDR is routed to")
+    private String gwIpAddress;
 
     @SerializedName(ApiConstants.CIDR)
-    @Param(description = "static route CIDR")
+    @Param(description = "The CIDR to route")
     private String cidr;
 
     @SerializedName(ApiConstants.ACCOUNT)
@@ -91,8 +91,8 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
         this.vpcId = vpcId;
     }
 
-    public void setGatewayId(String gatewayId) {
-        this.gatewayId = gatewayId;
+    public void setGwIpAddress(String gwIpAddress) {
+        this.gwIpAddress = gwIpAddress;
     }
 
     public void setCidr(String cidr) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
@@ -42,6 +42,10 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
     @Param(description = "VPC the static route belongs to")
     private String vpcId;
 
+    @SerializedName(ApiConstants.GATEWAY_ID)
+    @Param(description = "VPC gateway the route is created for")
+    private String gatewayId;
+
     @SerializedName(ApiConstants.IP_ADDRESS)
     @Param(description = "Gateway ip address the CIDR is routed to")
     private String gwIpAddress;
@@ -89,6 +93,10 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
 
     public void setVpcId(String vpcId) {
         this.vpcId = vpcId;
+    }
+
+    public void setGatewayId(String gatewayId) {
+        this.gatewayId = gatewayId;
     }
 
     public void setGwIpAddress(String gwIpAddress) {

--- a/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/StaticRouteResponse.java
@@ -42,10 +42,6 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
     @Param(description = "VPC the static route belongs to")
     private String vpcId;
 
-    @SerializedName(ApiConstants.GATEWAY_ID)
-    @Param(description = "VPC gateway the route is created for")
-    private String gatewayId;
-
     @SerializedName(ApiConstants.NEXT_HOP)
     @Param(description = "Gateway ip address the CIDR is routed to")
     private String gwIpAddress;
@@ -93,10 +89,6 @@ public class StaticRouteResponse extends BaseResponse implements ControlledEntit
 
     public void setVpcId(String vpcId) {
         this.vpcId = vpcId;
-    }
-
-    public void setGatewayId(String gatewayId) {
-        this.gatewayId = gatewayId;
     }
 
     public void setGwIpAddress(String gwIpAddress) {

--- a/engine/schema/src/main/java/com/cloud/network/vpc/StaticRouteVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/StaticRouteVO.java
@@ -60,6 +60,9 @@ public class StaticRouteVO implements StaticRoute {
     @Column(name = "domain_id")
     long domainId;
 
+    @Column(name = "gateway_ip_address")
+    String gwIpAddress;
+
     @Column(name = GenericDao.CREATED_COLUMN)
     Date created;
 
@@ -74,14 +77,14 @@ public class StaticRouteVO implements StaticRoute {
      * @param accountId TODO
      * @param domainId TODO
      */
-    public StaticRouteVO(long vpcGatewayId, String cidr, Long vpcId, long accountId, long domainId) {
-        super();
+    public StaticRouteVO(long vpcGatewayId, String cidr, Long vpcId, long accountId, long domainId, String gwIpAddress) {
         this.vpcGatewayId = vpcGatewayId;
         this.cidr = cidr;
         state = State.Staged;
         this.vpcId = vpcId;
         this.accountId = accountId;
         this.domainId = domainId;
+        this.gwIpAddress = gwIpAddress;
         uuid = UUID.randomUUID().toString();
     }
 
@@ -123,6 +126,11 @@ public class StaticRouteVO implements StaticRoute {
     @Override
     public long getDomainId() {
         return domainId;
+    }
+
+    @Override
+    public String getGwIpAddress() {
+        return gwIpAddress;
     }
 
     public void setState(State state) {

--- a/engine/schema/src/main/java/com/cloud/network/vpc/StaticRouteVO.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/StaticRouteVO.java
@@ -41,9 +41,6 @@ public class StaticRouteVO implements StaticRoute {
     @Column(name = "uuid")
     String uuid;
 
-    @Column(name = "vpc_gateway_id", updatable = false)
-    long vpcGatewayId;
-
     @Column(name = "cidr")
     private String cidr;
 
@@ -71,14 +68,12 @@ public class StaticRouteVO implements StaticRoute {
     }
 
     /**
-     * @param vpcGatewayId
      * @param cidr
      * @param vpcId
      * @param accountId TODO
      * @param domainId TODO
      */
-    public StaticRouteVO(long vpcGatewayId, String cidr, Long vpcId, long accountId, long domainId, String gwIpAddress) {
-        this.vpcGatewayId = vpcGatewayId;
+    public StaticRouteVO(String cidr, Long vpcId, long accountId, long domainId, String gwIpAddress) {
         this.cidr = cidr;
         state = State.Staged;
         this.vpcId = vpcId;
@@ -86,11 +81,6 @@ public class StaticRouteVO implements StaticRoute {
         this.domainId = domainId;
         this.gwIpAddress = gwIpAddress;
         uuid = UUID.randomUUID().toString();
-    }
-
-    @Override
-    public long getVpcGatewayId() {
-        return vpcGatewayId;
     }
 
     @Override
@@ -140,7 +130,7 @@ public class StaticRouteVO implements StaticRoute {
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder("StaticRoute[");
-        buf.append(uuid).append("|").append(cidr).append("|").append(vpcGatewayId).append("]");
+        buf.append(uuid).append("|").append(cidr).append("]");
         return buf.toString();
     }
 

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDao.java
@@ -29,7 +29,4 @@ public interface StaticRouteDao extends GenericDao<StaticRouteVO, Long> {
     List<? extends StaticRoute> listByVpcIdAndNotRevoked(long vpcId);
 
     List<StaticRouteVO> listByVpcId(long vpcId);
-
-    long countRoutesByGateway(long gatewayId);
-
 }

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
@@ -48,7 +48,7 @@ public class StaticRouteDaoImpl extends GenericDaoBase<StaticRouteVO, Long> impl
         super();
 
         AllFieldsSearch = createSearchBuilder();
-        AllFieldsSearch.and("gatewayId", AllFieldsSearch.entity().getVpcGatewayId(), Op.EQ);
+        AllFieldsSearch.and("gwIpAddress", AllFieldsSearch.entity().getGwIpAddress(), Op.EQ);
         AllFieldsSearch.and("vpcId", AllFieldsSearch.entity().getVpcId(), Op.EQ);
         AllFieldsSearch.and("state", AllFieldsSearch.entity().getState(), Op.EQ);
         AllFieldsSearch.and("id", AllFieldsSearch.entity().getId(), Op.EQ);
@@ -61,7 +61,7 @@ public class StaticRouteDaoImpl extends GenericDaoBase<StaticRouteVO, Long> impl
 
         RoutesByGatewayCount = createSearchBuilder(Long.class);
         RoutesByGatewayCount.select(null, Func.COUNT, RoutesByGatewayCount.entity().getId());
-        RoutesByGatewayCount.and("gatewayId", RoutesByGatewayCount.entity().getVpcGatewayId(), Op.EQ);
+        RoutesByGatewayCount.and("gwIpAddress", RoutesByGatewayCount.entity().getGwIpAddress(), Op.EQ);
         RoutesByGatewayCount.done();
     }
 

--- a/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/network/vpc/dao/StaticRouteDaoImpl.java
@@ -92,13 +92,6 @@ public class StaticRouteDaoImpl extends GenericDaoBase<StaticRouteVO, Long> impl
     }
 
     @Override
-    public long countRoutesByGateway(long gatewayId) {
-        SearchCriteria<Long> sc = RoutesByGatewayCount.create();
-        sc.setParameters("gatewayId", gatewayId);
-        return customSearch(sc, null).get(0);
-    }
-
-    @Override
     @DB
     public boolean remove(Long id) {
         TransactionLegacy txn = TransactionLegacy.currentTxn();

--- a/nucleo/src/main/java/com/cloud/agent/api/routing/SetStaticRouteCommand.java
+++ b/nucleo/src/main/java/com/cloud/agent/api/routing/SetStaticRouteCommand.java
@@ -19,13 +19,11 @@
 
 package com.cloud.agent.api.routing;
 
+import com.cloud.network.vpc.StaticRoute;
+import com.cloud.network.vpc.StaticRouteProfile;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import com.cloud.network.vpc.StaticRoute;
-import com.cloud.network.vpc.StaticRouteProfile;
-import com.cloud.utils.net.NetUtils;
 
 public class SetStaticRouteCommand extends NetworkElementCommand {
     StaticRouteProfile[] staticRoutes;
@@ -44,16 +42,11 @@ public class SetStaticRouteCommand extends NetworkElementCommand {
     public String[] generateSRouteRules() {
         Set<String> toAdd = new HashSet<String>();
         for (StaticRouteProfile route : staticRoutes) {
-            /*  example  :  ip:gateway:cidr,
-             */
-            String cidr = route.getCidr();
-            String subnet = NetUtils.getCidrSubNet(cidr);
-            String cidrSize = cidr.split("\\/")[1];
             String entry;
             if (route.getState() == StaticRoute.State.Active || route.getState() == StaticRoute.State.Add) {
-                entry = route.getIp4Address() + ":" + route.getGateway() + ":" + subnet + "/" + cidrSize;
+                entry = route.getIp4Address() + ":"  + route.getCidr();
             } else {
-                entry = "Revoke:" + route.getGateway() + ":" + subnet + "/" + cidrSize;
+                entry = "Revoke:" + route.getCidr();
             }
             toAdd.add(entry);
         }

--- a/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetStaticRouteConfigItem.java
+++ b/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/facade/SetStaticRouteConfigItem.java
@@ -30,7 +30,6 @@ import com.cloud.agent.resource.virtualnetwork.model.ConfigBase;
 import com.cloud.agent.resource.virtualnetwork.model.StaticRoute;
 import com.cloud.agent.resource.virtualnetwork.model.StaticRoutes;
 import com.cloud.network.vpc.StaticRouteProfile;
-import com.cloud.utils.net.NetUtils;
 
 public class SetStaticRouteConfigItem extends AbstractConfigItemFacade {
 
@@ -41,12 +40,9 @@ public class SetStaticRouteConfigItem extends AbstractConfigItemFacade {
         final LinkedList<StaticRoute> routes = new LinkedList<>();
 
         for (final StaticRouteProfile profile : command.getStaticRoutes()) {
-            final String cidr = profile.getCidr();
-            final String subnet = NetUtils.getCidrSubNet(cidr);
-            final String cidrSize = cidr.split("\\/")[1];
             final boolean keep = profile.getState() == com.cloud.network.vpc.StaticRoute.State.Active || profile.getState() == com.cloud.network.vpc.StaticRoute.State.Add;
 
-            routes.add(new StaticRoute(!keep, profile.getIp4Address(), profile.getGateway(), subnet + "/" + cidrSize));
+            routes.add(new StaticRoute(!keep, profile.getIp4Address(), profile.getCidr()));
         }
 
         return generateConfigItems(new StaticRoutes(routes));

--- a/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/StaticRoute.java
+++ b/nucleo/src/main/java/com/cloud/agent/resource/virtualnetwork/model/StaticRoute.java
@@ -22,19 +22,17 @@ package com.cloud.agent.resource.virtualnetwork.model;
 public class StaticRoute {
     private boolean revoke;
     private String ipAddress;
-    private String gateway;
-    private String network;
+    private String cidr;
 
     public StaticRoute() {
         // Empty constructor for (de)serialization
     }
 
-    public StaticRoute(boolean revoke, String ipAddress, String gateway, String network) {
+    public StaticRoute(boolean revoke, String ipAddress, String cidr) {
         super();
         this.revoke = revoke;
         this.ipAddress = ipAddress;
-        this.gateway = gateway;
-        this.network = network;
+        this.cidr = cidr;
     }
 
     public boolean isRevoke() {
@@ -53,20 +51,12 @@ public class StaticRoute {
         this.ipAddress = ipAddress;
     }
 
-    public String getGateway() {
-        return gateway;
+    public String getCidr() {
+        return cidr;
     }
 
-    public void setGateway(String gateway) {
-        this.gateway = gateway;
-    }
-
-    public String getNetwork() {
-        return network;
-    }
-
-    public void setNetwork(String network) {
-        this.network = network;
+    public void setCidr(String cidr) {
+        this.cidr = cidr;
     }
 
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -2930,6 +2930,7 @@ public class ApiResponseHelper implements ResponseGenerator {
       }
     }
     response.setCidr(result.getCidr());
+    response.setGwIpAddress(result.getGwIpAddress());
 
     StaticRoute.State state = result.getState();
     if (state.equals(StaticRoute.State.Revoke)) {

--- a/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcVirtualNetworkApplianceManagerImpl.java
@@ -406,15 +406,14 @@ public class VpcVirtualNetworkApplianceManagerImpl extends VirtualNetworkApplian
 
             // 4) RE-APPLY ALL STATIC ROUTE RULES
             final List<? extends StaticRoute> routes = _staticRouteDao.listByVpcId(domainRouterVO.getVpcId());
-            final List<StaticRouteProfile> staticRouteProfiles = new ArrayList<StaticRouteProfile>(routes.size());
-            final Map<Long, VpcGateway> gatewayMap = new HashMap<Long, VpcGateway>();
+            final List<StaticRouteProfile> staticRouteProfiles = new ArrayList<>(routes.size());
+
+            final Map<String, String> cidrGwIpMap = new HashMap<>();
+
             for (final StaticRoute route : routes) {
-                VpcGateway gateway = gatewayMap.get(route.getVpcGatewayId());
-                if (gateway == null) {
-                    gateway = _entityMgr.findById(VpcGateway.class, route.getVpcGatewayId());
-                    gatewayMap.put(gateway.getId(), gateway);
-                }
-                staticRouteProfiles.add(new StaticRouteProfile(route, gateway));
+                cidrGwIpMap.put(route.getCidr(), route.getGwIpAddress());
+
+                staticRouteProfiles.add(new StaticRouteProfile(route));
             }
 
             s_logger.debug("Found " + staticRouteProfiles.size() + " static routes to apply as a part of vpc route " + domainRouterVO + " start");

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2096,6 +2096,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
       throw new InvalidParameterValueException("Invalid format for cidr " + cidr);
     }
 
+    if (!NetUtils.isValidIp(gwIpAddress)) {
+      throw new InvalidParameterValueException("Invalid format for ip address " + gwIpAddress);
+    }
+
     // validate the cidr
     // 1) CIDR should be outside of VPC cidr for guest networks
     if (NetUtils.isNetworksOverlap(vpc.getCidr(), cidr)) {

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2117,7 +2117,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     return Transaction.execute(new TransactionCallbackWithException<StaticRouteVO, NetworkRuleConflictException>() {
       @Override
       public StaticRouteVO doInTransaction(final TransactionStatus status) throws NetworkRuleConflictException {
-        StaticRouteVO newRoute = new StaticRouteVO(0l, cidr, vpc.getId(), vpc.getAccountId(),
+        StaticRouteVO newRoute = new StaticRouteVO(cidr, vpc.getId(), vpc.getAccountId(),
             vpc.getDomainId(), gwIpAddress);
         s_logger.debug("Adding static route " + newRoute);
         newRoute = _staticRouteDao.persist(newRoute);
@@ -2181,7 +2181,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
 
     sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
     sb.and("vpcId", sb.entity().getVpcId(), SearchCriteria.Op.EQ);
-    sb.and("vpcGatewayId", sb.entity().getVpcGatewayId(), SearchCriteria.Op.EQ);
+    sb.and("gwIpAddress", sb.entity().getGwIpAddress(), SearchCriteria.Op.EQ);
 
     if (tags != null && !tags.isEmpty()) {
       final SearchBuilder<ResourceTagVO> tagSearch = _resourceTagDao.createSearchBuilder();

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2100,19 +2100,13 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
       throw new InvalidParameterValueException("Invalid format for ip address " + gwIpAddress);
     }
 
-    // validate the cidr
-    // 1) CIDR should be outside of VPC cidr for guest networks
-    if (NetUtils.isNetworksOverlap(vpc.getCidr(), cidr)) {
-      throw new InvalidParameterValueException("CIDR should be outside of VPC cidr " + vpc.getCidr());
-    }
-
-    // 2) CIDR should be outside of link-local cidr
-    if (NetUtils.isNetworksOverlap(vpc.getCidr(), NetUtils.getLinkLocalCIDR())) {
+    // CIDR should be outside of link-local cidr
+    if (NetUtils.isNetworksOverlap(cidr, NetUtils.getLinkLocalCIDR())) {
       throw new InvalidParameterValueException(
           "CIDR should be outside of link local cidr " + NetUtils.getLinkLocalCIDR());
     }
 
-    // 3) Verify against blacklisted routes
+    // Verify against blacklisted routes
     if (isCidrBlacklisted(cidr, vpc.getZoneId())) {
       throw new InvalidParameterValueException(
           "The static gateway cidr overlaps with one of the blacklisted routes of the zone the VPC belongs to");

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2154,7 +2154,8 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
   @Override
   public Pair<List<? extends StaticRoute>, Integer> listStaticRoutes(final ListStaticRoutesCmd cmd) {
     final Long id = cmd.getId();
-    final Long gatewayId = cmd.getGatewayId();
+    final String gwIpAddress = cmd.getGwIpAddress();
+    final String cidr = cmd.getCidr();
     final Long vpcId = cmd.getVpcId();
     Long domainId = cmd.getDomainId();
     Boolean isRecursive = cmd.isRecursive();
@@ -2182,6 +2183,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     sb.and("id", sb.entity().getId(), SearchCriteria.Op.EQ);
     sb.and("vpcId", sb.entity().getVpcId(), SearchCriteria.Op.EQ);
     sb.and("gwIpAddress", sb.entity().getGwIpAddress(), SearchCriteria.Op.EQ);
+    sb.and("cidr", sb.entity().getCidr(), SearchCriteria.Op.EQ);
 
     if (tags != null && !tags.isEmpty()) {
       final SearchBuilder<ResourceTagVO> tagSearch = _resourceTagDao.createSearchBuilder();
@@ -2206,8 +2208,12 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
       sc.addAnd("vpcId", Op.EQ, vpcId);
     }
 
-    if (gatewayId != null) {
-      sc.addAnd("vpcGatewayId", Op.EQ, gatewayId);
+    if (gwIpAddress != null) {
+      sc.addAnd("gwIpAddress", Op.EQ, gwIpAddress);
+    }
+
+    if (cidr != null) {
+      sc.addAnd("cidr", Op.EQ, cidr);
     }
 
     if (tags != null && !tags.isEmpty()) {

--- a/setup/db/db/schema-501to510.sql
+++ b/setup/db/db/schema-501to510.sql
@@ -1,3 +1,45 @@
 --;
 -- Schema upgrade from 5.0.1 to 5.1.0;
 --;
+
+-- Get rid of old foreign keys
+ALTER TABLE `cloud`.`static_routes` DROP FOREIGN KEY `fk_static_routes__vpc_gateway_id`;
+ALTER TABLE `cloud`.`static_routes` DROP FOREIGN KEY `fk_static_routes__vpc_id`;
+ALTER TABLE `cloud`.`static_routes` DROP FOREIGN KEY `fk_static_routes__account_id`;
+ALTER TABLE `cloud`.`static_routes` DROP FOREIGN KEY `fk_static_routes__domain_id`;
+
+-- Backup table for later reference
+RENAME TABLE `cloud`.`static_routes` TO `cloud`.`static_routes_pre510`;
+
+-- Create new table
+CREATE TABLE `cloud`.`static_routes` (
+  `id` bigint unsigned NOT NULL auto_increment COMMENT 'id',
+  `uuid` varchar(40),
+  `cidr` varchar(18) COMMENT 'cidr for the static route',
+  `gateway_ip_address` varchar(45) COMMENT 'gateway ip address for the static route',
+  `state` char(32) NOT NULL COMMENT 'current state of this rule',
+  `vpc_id` bigint unsigned COMMENT 'vpc the firewall rule is associated with',
+  `account_id` bigint unsigned NOT NULL COMMENT 'owner id',
+  `domain_id` bigint unsigned NOT NULL COMMENT 'domain id',
+  `created` datetime COMMENT 'Date created',
+  PRIMARY KEY  (`id`),
+  CONSTRAINT `fk_static_routes__vpc_id` FOREIGN KEY (`vpc_id`) REFERENCES `vpc`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_static_routes__account_id` FOREIGN KEY(`account_id`) REFERENCES `account`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_static_routes__domain_id` FOREIGN KEY(`domain_id`) REFERENCES `domain`(`id`) ON DELETE CASCADE,
+  CONSTRAINT `uc_static_routes__uuid` UNIQUE (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Migrate data from old to new
+INSERT INTO `cloud`.`static_routes`
+(`id`, `uuid`, `cidr`, `gateway_ip_address`, `state`, `vpc_id`, `account_id`, `domain_id`, `created`)
+SELECT  `static_routes_pre510`.id,
+  `static_routes_pre510`.uuid,
+  `static_routes_pre510`.cidr,
+  `vpc_gateways`.ip4_address,
+  `static_routes_pre510`.state,
+  `static_routes_pre510`.vpc_id,
+  `static_routes_pre510`.account_id,
+  `static_routes_pre510`.domain_id,
+  `static_routes_pre510`.created
+FROM `cloud`.`static_routes_pre510`, `cloud`.vpc_gateways
+WHERE `static_routes_pre510`.vpc_gateway_id = vpc_gateways.id;

--- a/setup/db/db/schema-501to510.sql
+++ b/setup/db/db/schema-501to510.sql
@@ -17,6 +17,7 @@ CREATE TABLE `cloud`.`static_routes` (
   `uuid` varchar(40),
   `cidr` varchar(18) COMMENT 'cidr for the static route',
   `gateway_ip_address` varchar(45) COMMENT 'gateway ip address for the static route',
+  `metric` INT(10) DEFAULT 100 COMMENT 'metric value for the route',
   `state` char(32) NOT NULL COMMENT 'current state of this rule',
   `vpc_id` bigint unsigned COMMENT 'vpc the firewall rule is associated with',
   `account_id` bigint unsigned NOT NULL COMMENT 'owner id',

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsHelper.py
@@ -25,6 +25,7 @@ import os.path
 import re
 import shutil
 from netaddr import *
+from subprocess import check_output
 from pprint import pprint
 
 PUBLIC_INTERFACES = {"router" : "eth2", "vpcrouter" : "eth1"}
@@ -206,6 +207,11 @@ def execute2(command):
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     p.wait()
     return p
+
+def get_output_of_command(command):
+    """ Execute command """
+    logging.debug("Executing command and returning output: %s" % command)
+    return check_output(command,shell=True)
 
 
 def service(name, op):

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -19,6 +19,7 @@
 
 from CsDatabag import CsDataBag
 from CsRedundant import *
+import sys
 
 
 class CsStaticRoutes(CsDataBag):
@@ -28,15 +29,63 @@ class CsStaticRoutes(CsDataBag):
         for item in self.dbag:
             if item == "id":
                 continue
-            self.__update(self.dbag[item])
+            result = self.__update(self.dbag[item])
+            logging.debug("Processing item from data bag: %s, returncode: %s" % (self.dbag[item], result))
+            if result is not None and result is False:
+                logging.debug("Executing static route command returned False, exiting.")
+                sys.exit(1)
+
+    def get_routes(self):
+        try:
+            if len(self.routes) == 0:
+                self.set_routes()
+        except:
+            self.set_routes()
+        return self.routes
+
+    def set_routes(self):
+        command = "ip route show | grep via | awk '{print $1, $3}'"
+        output = CsHelper.get_output_of_command(command)
+        self.routes = {}
+        for line in output.split('\n'):
+            data = line.split()
+            if data:
+                key = data.pop(0)
+                self.routes[key] = data
+        logging.debug("Found these existing routes: %s" % self.routes)
+        return self.routes
+
+    def route_exists(self, cidr):
+        if cidr in self.routes:
+            return True
+        return False
 
     def __update(self, route):
-        if route['revoke']:
-            command = "ip route del %s via %s" % (route['network'], route['gateway'])
-            CsHelper.execute(command)
-        else:
-            command = "ip route show | grep %s | awk '{print $1, $3}'" % route['network']
-            result = CsHelper.execute(command)
-            if not result:
-                route_command = "ip route add %s via %s" % (route['network'], route['gateway'])
-                CsHelper.execute(route_command)
+        # Compatibility with old names pre 5.1.0
+        if 'cidr' not in route:
+            route['cidr'] = route['network']
+        if 'ip_address' not in route:
+            route['ip_address'] = route['gateway']
+
+        self.get_routes()
+
+        # /32 routes do not need a CIDR notation for adding, and should not have it for deleting
+        if route['cidr'].find('/32') > -1:
+            logging.debug("Stripping /32 from cidr %s" % route['cidr'])
+            route['cidr'] = route['cidr'].replace('/32', '')
+
+        # Only delete when the route is active
+        if route['revoke'] and self.route_exists(route['cidr']):
+            logging.debug("Route for %s to %s found, deleting.." % (route['cidr'], route['ip_address']))
+            command = "ip route del %s" % (route['cidr'])
+            result = CsHelper.execute2(command)
+            logging.debug("Executed %s, returncode: %s" % (command, result.returncode))
+
+        # Only add when route is not active yet
+        if not route['revoke'] and not self.route_exists(route['cidr']):
+            logging.debug("Route for %s to %s NOT found, adding.." % (route['cidr'], route['ip_address']))
+            command = "ip route add %s via %s" % (route['cidr'], route['ip_address'])
+            result = CsHelper.execute2(command)
+            logging.debug("Executed %s, returncode: %s" % (command, result.returncode))
+            if result.returncode > 0:
+                return False

--- a/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs_staticroutes.py
@@ -20,6 +20,6 @@ from pprint import pprint
 
 def merge(dbag, staticroutes):
     for route in staticroutes['routes']:
-        key = route['network']
+        key = route['cidr']
         dbag[key] = route
     return dbag

--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -1535,6 +1535,9 @@ public class NetUtils {
         if (!isValidCIDR(cidr)) {
             return false;
         }
+        if (cidr.equals("0.0.0.0/0")) {
+            return true;
+        }
 
         // check if the gatewayip is the part of the ip range being added.
         // RFC 3021 - 31-Bit Prefixes on IPv4 Point-to-Point Links


### PR DESCRIPTION
This PR moves static routes functionality from `private gateways` to the `VPC` itself. This allows for far greater flexibility and control over the `VPC` router.

Basic concept:
![image](https://cloud.githubusercontent.com/assets/1630096/15635711/acefcf9a-25e6-11e6-8de9-789f3bd58fe6.png)

The `createStaticRoute` and `listStaticRoute` API commands have been adjusted to add extra parameters. 

Any route that is accepted by the kernel will work. Should it fail, an `Error 530` is returned to the user.

A new static route can be made like this:

```
(local) 🐵 > create staticroute vpcid=<id> cidr=1.2.3.4/32 ipaddress=10.0.0.18
```

Listing now shows both the `cidr` and `ipadddress` that we route the `cidr` to:

```
(local) 🐵 > list staticroutes filter=cidr,ipaddress                                                                                                                                                                                                                                                       
count = 9
staticroute:
+-----------------+------------+
|       cidr      | ipaddress  |
+-----------------+------------+
|    1.2.3.4/32   | 10.0.0.18  |
|   10.1.0.0/16   | 10.0.0.128 |
|   9.24.0.0/26   | 10.0.0.126 |
| 192.169.16.0/26 | 10.0.0.128 |
| 192.169.14.0/24 | 10.0.0.111 |
| 192.169.14.0/29 | 10.0.0.111 |
| 192.169.13.0/29 | 10.0.0.111 |
| 192.169.13.0/28 | 10.0.0.31  |
| 192.169.13.0/26 |  10.0.0.3  |
+-----------------+------------+
```

New checks have been implemented, for example to allow a `cidr` to be added only once:

```
(local) 🐵 > create staticroute vpcid=<id> cidr=1.2.3.4/32 ipaddress=10.0.0.18
Error 537: New static route cidr already exists in VPC. UUID of existing static route is 4d0e7633-a9a6-4ffd-9625-5e1a3c1070a5
```

Also the `ipaddress` has input validation:

```
(local) 🐵 > create staticroute vpcid=<id> cidr=1.2.3.4/24 ipaddress=remi                                                                                                                                                                                                
Error 431: Invalid format for ip address remi
```

And the `cidr` too:

```
(local) 🐵 > create staticroute vpcid=<id> cidr=1.2.3.4 ipaddress=10.0.0.10
Error 431: Invalid format for cidr 1.2.3.4
```

The `cidr` may not conflict with `LinkLocal` as this will render the VPC unmanageable by Cosmic.

```
(local) 🐵 > create staticroute vpcid=<id> cidr=169.254.0.0/16 ipaddress=10.0.0.10
Error 431: CIDR should be outside of link local cidr 169.254.0.0/16

(local) 🐵 > create staticroute vpcid=<id> cidr=169.254.1.0/24 ipaddress=10.0.0.10
Error 431: CIDR should be outside of link local cidr 169.254.0.0/16
```

Deleting a static route works unchanged:

```
(local) 🐵 > delete staticroute id=<id>
```

Deleting a `private gateway` and `network tier` also had to be improved. This is because when they are removed, certain static routes won't work any more. Checks were added for these.

```
(local) 🐵 > delete privategateway id=<id>
Async job 2815849e-466d-4e5f-a5dd-cffe4a648890 failed
Error 530, Can't delete private gateway VpcGateway[18|10.223.22.2|1] as it has static routes applied pointing to the CIDR of the gateway (10.223.22.0/24). Example static route: 10.252.0.0/24 to 10.223.22.1. Please remove all the routes pointing to the private gateway CIDR before attempting to delete it.
```

![screen shot 2016-05-28 at 22 13 54](https://cloud.githubusercontent.com/assets/1630096/15632999/72a6938a-25a2-11e6-8b5f-c570e21366c4.png)

The same for network tiers:

```
(local) 🐵 > delete network id=<id>
Async job 314dc560-4739-4e31-82a5-08a59fa9e430 failed
Error 530, Can't delete network network2 as it has static routes applied pointing to the CIDR of the network (10.0.1.0/24). Example static route: 10.252.111.0/24 to 10.0.1.111. Please remove all the routes pointing to the network tier CIDR before attempting to delete it.
```

![screen shot 2016-05-28 at 22 43 26](https://cloud.githubusercontent.com/assets/1630096/15633001/7d296936-25a2-11e6-9cea-0fda45a2419f.png)

**Incompatibilities**:
Everything is made backwards compatible now, although the old behaviour of using the `gatewayId` is deprecated and should be removed in `5.2` or `5.3`.

**API changes**:

_API call `createStaticRoute`:_
- needs parameter `vpcId` instead of `gatewayId`
- needs new parameter `IpAddress` (when  `gatewayId` is not specified)

Parameter `gatewayid` still works, but is deprecated. It is used to lookup `vpcId` and `ipaddress` and will be removed in an upcoming release.

Extra checks:

```
(local) 🐵 > create staticroute cidr=1.2.3.0/24
Error 431: VpcId should not be empty. Either specify VpcId (recommended) or specify gatewayId (deprecated).
```

```
(local) 🐵 > create staticroute cidr=1.2.3.0/24 vpcid=<id>
Error 431: IpAddress should not be empty. Either specify IpAddress (recommended) or specify gatewayId (deprecated).
```

So this still works (but is deprecated):

```
(local) 🐵 > create staticroute cidr=1.2.3.0/24 gatewayid=<id>
```

_API call `listStaticRoutes`:_
- needs parameter `vpcId` instead of `gatewayId`
- still supports `gatewayId` but that is deprecated

Parameter `gatewayid` still works, but is deprecated. Since the `gatewayId` is no longer in the DB, there is no way to match it in the DB. Instead, we get all results and filter by matching the gateway ip addresses to the private gateway CIDR.

Example:

```
(local) 🐵 > list staticroutes filter=ipaddress,cidr
count = 17
staticroute:
+-----------------+-------------+
|       cidr      |  ipaddress  |
+-----------------+-------------+
| 10.252.111.0/24 |  10.0.1.111 |
|    1.2.2.0/24   | 10.223.22.1 |
|    1.2.3.0/24   |  10.0.0.111 |
|  10.252.1.0/24  |   10.0.0.2  |
|  10.252.0.0/24  | 10.223.22.1 |
|  10.2.131.0/24  |  10.0.0.12  |
|  10.253.22.0/27 |  10.0.0.110 |
|  10.253.22.0/24 |  10.0.0.110 |
|  10.253.12.0/23 |  10.0.0.110 |
|  10.253.12.0/24 |  10.0.0.110 |
|  10.253.2.0/32  |  10.0.0.10  |
|  10.253.1.0/24  |  10.0.0.10  |
| 192.169.14.0/24 |  10.0.0.111 |
| 192.169.14.0/29 |  10.0.0.111 |
| 192.169.13.0/29 |  10.0.0.111 |
| 192.169.13.0/28 |  10.0.0.31  |
| 192.169.13.0/26 |   10.0.0.3  |
+-----------------+-------------+
(local) 🐵 > list staticroutes gatewayid=<id> filter=ipaddress,cidr,
count = 17
staticroute:
+---------------+-------------+
|      cidr     |  ipaddress  |
+---------------+-------------+
|   1.2.2.0/24  | 10.223.22.1 |
| 10.252.0.0/24 | 10.223.22.1 |
+---------------+-------------+
```

This PR can be merged when:
- The poms point to `5.1.0.0-SNAPSHOT`
- PR #166 is merged
- This PR is rebased (will have small conflict with #166)
