### PR TITLE
Fix/test router reboot

### DIFF
--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -668,6 +668,25 @@ class TestRebootRouter(cloudstackTestCase):
     def test_reboot_router(self):
         """Test for reboot router"""
 
+        # Before restart validate the VM can be accessed;
+        #    if the router restarts while the VM has not finished starting,
+        #    the VM will fail to get an IP from the router
+        try:
+            logger.debug("SSH into VM (ID : %s ) before reboot of router" % self.vm_1.id)
+
+            SshClient(
+                self.public_ip.ipaddress.ipaddress,
+                self.services["natrule"]["publicport"],
+                self.vm_1.username,
+                self.vm_1.password,
+                retries=20
+            )
+        except Exception as e:
+            self.fail(
+                "SSH Access failed for %s: %si, before reboot of Router" %
+                (self.public_ip.ipaddress.ipaddress, e))
+
+
         # Validate the Following
         # 1. Post restart PF and LB rules should still function
         # 2. verify if the ssh into the virtual machine

--- a/test/integration/smoke/test_network.py
+++ b/test/integration/smoke/test_network.py
@@ -719,8 +719,6 @@ class TestRebootRouter(cloudstackTestCase):
         timeout = self.services["timeout"]
 
         while True:
-            time.sleep(self.services["sleep"])
-
             # Ensure that VM is in stopped state
             list_vm_response = list_virtual_machines(
                 self.apiclient,
@@ -739,6 +737,7 @@ class TestRebootRouter(cloudstackTestCase):
                     "Failed to start VM (ID: %s) in change service offering" %
                     vm.id)
 
+            time.sleep(self.services["sleep"])
             timeout = timeout - 1
 
         # we should be able to SSH after successful reboot
@@ -750,7 +749,7 @@ class TestRebootRouter(cloudstackTestCase):
                 self.services["natrule"]["publicport"],
                 self.vm_1.username,
                 self.vm_1.password,
-                retries=5
+                retries=20
             )
         except Exception as e:
             self.fail(


### PR DESCRIPTION
Short version:

```
[root@cs1 smoke]# tail -f results.txt
Test for reboot router ... === TestName: test_reboot_router | Status : SUCCESS ===ok

----------------------------------------------------------------------
Ran 1 test in 440.146s

OK
```

Long version:

```
[root@cs1 smoke]# nosetests --with-marvin --marvin-config /data/shared/marvin/mct-zone1-kvm1-kvm2.cfg  -s -a tags=advanced,required_hardware=true test_network.py:TestRebootRouter
[INFO] 2016-05-30 16:16:26,985 - marvin - === Marvin Init Logging Successful ===
[INFO] 2016-05-30 16:16:26,985 - marvin - === Marvin Init Started ===
[INFO] 2016-05-30 16:16:26,988 - marvin - === Marvin Parse Config Successful ===
[INFO] 2016-05-30 16:16:26,988 - marvin - === Marvin Setting TestData Successful ===
[INFO] 2016-05-30 16:16:26,999 - marvin - Parsing Test data successful
[INFO] 2016-05-30 16:16:27,015 - marvin - === Test Client Creation Successful ===
[INFO] 2016-05-30 16:16:27,015 - marvin - === Marvin Init Successful ===
[INFO] 2016-05-30 16:16:27,114 - test_reboot_router (integration.smoke.test_network.TestRebootRouter) - === Started Test test_reboot_router ===
SSH into VM (ID : 0c79ea48-cd5a-4221-8e5f-7f59b0c7e4b3 ) before reboot of router
[INFO] 2016-05-30 16:20:08,504 - ssh - Trying SSH Connection to host 192.168.23.7 on port 22 as user root. RetryCount: 20
[ERROR] 2016-05-30 16:20:10,868 - ssh - Failed to create connection: [Errno None] Unable to connect to port 22 on 192.168.23.7
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/marvin/sshClient.py", line 99, in createConnection
    timeout=self.timeout)
  File "/usr/lib/python2.7/site-packages/paramiko/client.py", line 324, in connect
    raise NoValidConnectionsError(errors)
NoValidConnectionsError: [Errno None] Unable to connect to port 22 on 192.168.23.7
[INFO] 2016-05-30 16:20:20,879 - ssh - Trying SSH Connection to host 192.168.23.7 on port 22 as user root. RetryCount: 19
[ERROR] 2016-05-30 16:20:22,884 - ssh - Failed to create connection: [Errno None] Unable to connect to port 22 on 192.168.23.7
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/marvin/sshClient.py", line 99, in createConnection
    timeout=self.timeout)
  File "/usr/lib/python2.7/site-packages/paramiko/client.py", line 324, in connect
    raise NoValidConnectionsError(errors)
NoValidConnectionsError: [Errno None] Unable to connect to port 22 on 192.168.23.7
[INFO] 2016-05-30 16:20:32,895 - ssh - Trying SSH Connection to host 192.168.23.7 on port 22 as user root. RetryCount: 18
[ERROR] 2016-05-30 16:20:34,900 - ssh - Failed to create connection: [Errno None] Unable to connect to port 22 on 192.168.23.7
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/marvin/sshClient.py", line 99, in createConnection
    timeout=self.timeout)
  File "/usr/lib/python2.7/site-packages/paramiko/client.py", line 324, in connect
    raise NoValidConnectionsError(errors)
NoValidConnectionsError: [Errno None] Unable to connect to port 22 on 192.168.23.7
[INFO] 2016-05-30 16:20:44,910 - ssh - Trying SSH Connection to host 192.168.23.7 on port 22 as user root. RetryCount: 17
[INFO] 2016-05-30 16:20:45,557 - ssh - Connection to host 192.168.23.7 on port 22 is SUCCESSFUL
Public IP: 10.1.1.4
Public IP: 192.168.23.7
Rebooting the router (ID: 96b5dd2f-bb12-4315-9586-41d1c0c2f4c2)
VM state: Running
SSH into VM (ID : 0c79ea48-cd5a-4221-8e5f-7f59b0c7e4b3 ) after reboot
[INFO] 2016-05-30 16:22:56,224 - ssh - Trying SSH Connection to host 192.168.23.7 on port 22 as user root. RetryCount: 20
[INFO] 2016-05-30 16:22:56,785 - ssh - Connection to host 192.168.23.7 on port 22 is SUCCESSFUL
[INFO] 2016-05-30 16:23:47,259 - test_reboot_router (integration.smoke.test_network.TestRebootRouter) - === TestName: test_reboot_router | Status : SUCCESS ===
[INFO] 2016-05-30 16:23:47,259 - test_reboot_router (integration.smoke.test_network.TestRebootRouter) - TestCaseName: test_reboot_router; Time Taken: 440 Seconds; StartTime: Mon May 30 16:16:27 2016; EndTime: Mon May 30 16:23:47 2016; Result: SUCCESS
[INFO] 2016-05-30 16:23:47,260 - test_reboot_router (integration.smoke.test_network.TestRebootRouter) - === finalize does nothing!  ===
```
