### PR TITLE
VPC without SourceNat service and external gateway

### DIFF
--- a/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/NicProfileHelperImpl.java
@@ -117,7 +117,9 @@ public class NicProfileHelperImpl implements NicProfileHelper {
     public NicProfile createGuestNicProfileForVpcRouter(final RouterDeploymentDefinition vpcRouterDeploymentDefinition, final Network guestNetwork) {
         final NicProfile guestNic = new NicProfile();
 
-        if (vpcRouterDeploymentDefinition.isRedundant()) {
+        // Redundant VPCs should not acquire the gateway ip because that is the VIP between the two routers to which guest VMs connect
+        // VPCs without sourcenat service also should not acquire the gateway ip because it is in use by an external device on the network
+        if (vpcRouterDeploymentDefinition.isRedundant() || ! vpcRouterDeploymentDefinition.hasSourceNatService()) {
             guestNic.setIPv4Address(_ipAddrMgr.acquireGuestIpAddress(guestNetwork, null));
         } else {
             guestNic.setIPv4Address(guestNetwork.getGateway());

--- a/server/src/main/java/com/cloud/network/router/VpcNetworkHelperImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VpcNetworkHelperImpl.java
@@ -83,7 +83,11 @@ public class VpcNetworkHelperImpl extends NetworkHelperImpl {
             throws ConcurrentOperationException, InsufficientCapacityException {
 
         final TreeSet<String> publicVlans = new TreeSet<String>();
-        publicVlans.add(vpcRouterDeploymentDefinition.getSourceNatIP().getVlanTag());
+        if (vpcRouterDeploymentDefinition.needsPublicNic()) {
+            publicVlans.add(vpcRouterDeploymentDefinition.getSourceNatIP().getVlanTag());
+        } else {
+            s_logger.debug("VPC " + vpcRouterDeploymentDefinition.getVpc().getName() + " does not need a public nic.");
+        }
 
         //1) allocate nic for control and source nat public ip
         final LinkedHashMap<Network, List<? extends NicProfile>> networks = configureDefaultNics(vpcRouterDeploymentDefinition);

--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -350,7 +350,6 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
     sdnProviders.add(Provider.JuniperContrailVpcRouter);
     sdnProviders.add(Provider.NuageVsp);
 
-    boolean sourceNatSvc = false;
     boolean firewallSvs = false;
     // populate the services first
     for (final String serviceName : supportedServices) {
@@ -369,15 +368,6 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
       if (service == Service.NetworkACL) {
         firewallSvs = true;
       }
-
-      if (service == Service.SourceNat) {
-        sourceNatSvc = true;
-      }
-    }
-
-    if (!sourceNatSvc) {
-      s_logger.debug("Automatically adding source nat service to the list of VPC services");
-      svcProviderMap.put(Service.SourceNat, defaultProviders);
     }
 
     if (!firewallSvs) {
@@ -1345,22 +1335,7 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
       }
     }
 
-    // 2) Only Isolated networks with Source nat service enabled can be
-    // added to vpc
-    if (!(guestNtwkOff.getGuestType() == GuestType.Isolated && supportedSvcs.contains(Service.SourceNat))) {
-
-      throw new InvalidParameterValueException(
-          "Only network offerings of type " + GuestType.Isolated + " with service " + Service.SourceNat.getName()
-          + " are valid for vpc ");
-    }
-
-    // 3) No redundant router support
-    /*
-     * TODO This should have never been hardcoded like this in the first place if (guestNtwkOff.getRedundantRouter()) {
-     * throw new InvalidParameterValueException ("No redunant router support when network belnogs to VPC"); }
-     */
-
-    // 4) Conserve mode should be off
+    // 2) Conserve mode should be off
     if (guestNtwkOff.isConserveMode()) {
       throw new InvalidParameterValueException("Only networks with conserve mode Off can belong to VPC");
     }

--- a/server/src/main/java/org/cloud/network/router/deployment/RouterDeploymentDefinition.java
+++ b/server/src/main/java/org/cloud/network/router/deployment/RouterDeploymentDefinition.java
@@ -108,7 +108,7 @@ public class RouterDeploymentDefinition {
     protected PublicIp sourceNatIp;
 
     protected RouterDeploymentDefinition(final Network guestNetwork, final DeployDestination dest,
-            final Account owner, final Map<Param, Object> params) {
+                                         final Account owner, final Map<Param, Object> params) {
 
         this.guestNetwork = guestNetwork;
         this.dest = dest;
@@ -178,6 +178,14 @@ public class RouterDeploymentDefinition {
 
     public PublicIp getSourceNatIP() {
         return sourceNatIp;
+    }
+
+    public boolean needsPublicNic() {
+        return isPublicNetwork;
+    }
+
+    public boolean hasSourceNatService() {
+        return isPublicNetwork;
     }
 
     protected void generateDeploymentPlan() {

--- a/server/src/test/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
+++ b/server/src/test/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
@@ -28,11 +28,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+
+import com.google.common.collect.Maps;
 
 import com.cloud.deploy.DeployDestination;
 import com.cloud.exception.ConcurrentOperationException;
@@ -41,6 +45,7 @@ import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.InsufficientServerCapacityException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.exception.StorageUnavailableException;
+import com.cloud.network.Network;
 import com.cloud.network.addr.PublicIp;
 import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkServiceProviderDao;
@@ -168,9 +173,44 @@ public class VpcRouterDeploymentDefinitionTest extends RouterDeploymentDefinitio
         assertEquals("If there is already a router found, there is no need to deploy more", 0, deployment.getNumberOfRoutersToDeploy());
     }
 
+    protected void driveTestPrepareDeployment(final boolean isRedundant, final boolean isPublicNw) {
+        // Prepare
+        when(mockVpc.isRedundant()).thenReturn(isRedundant);
+
+        final Set<Network.Provider> providers = mock(Set.class);
+        final Map<Network.Service, Set<Network.Provider>> vpcOffSvcProvidersMap = Maps.newHashMap();
+        vpcOffSvcProvidersMap.put(Network.Service.SourceNat, providers);
+
+        when(vpcMgr.getVpcOffSvcProvidersMap(VPC_OFFERING_ID)).thenReturn(vpcOffSvcProvidersMap);
+        when(providers.contains(Network.Provider.VPCVirtualRouter)).thenReturn(isPublicNw);
+
+        // Execute
+        final boolean canProceedDeployment = deployment.prepareDeployment();
+        // Assert
+        boolean shouldProceedDeployment = true;
+        if (isRedundant && !isPublicNw) {
+            shouldProceedDeployment = false;
+        }
+        assertEquals(shouldProceedDeployment, canProceedDeployment);
+        if (!shouldProceedDeployment) {
+            assertEquals("Since deployment cannot proceed we should empty the list of routers",
+                    0, deployment.routers.size());
+        }
+    }
+
     @Test
-    public void testPrepareDeployment() {
-        assertTrue("There are no preconditions for Vpc Deployment, thus it should always pass", deployment.prepareDeployment());
+    public void testPrepareDeploymentPublicNw() {
+        driveTestPrepareDeployment(true, true);
+    }
+
+    @Test
+    public void testPrepareDeploymentNonRedundant() {
+        driveTestPrepareDeployment(false, true);
+    }
+
+    @Test
+    public void testPrepareDeploymentNonRedundantNonPublicNw() {
+        driveTestPrepareDeployment(false, false);
     }
 
     @Test

--- a/server/src/test/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
+++ b/server/src/test/java/org/cloud/network/router/deployment/VpcRouterDeploymentDefinitionTest.java
@@ -290,8 +290,14 @@ public class VpcRouterDeploymentDefinitionTest extends RouterDeploymentDefinitio
         // Execute
         deployment.findSourceNatIP();
 
-        // Assert
-        assertEquals("SourceNatIp returned by the VpcManager was not correctly set", publicIp, deployment.sourceNatIp);
+        final VpcRouterDeploymentDefinition vpcDeployment = (VpcRouterDeploymentDefinition) deployment;
+        if (vpcDeployment.hasSourceNatService()) {
+            // Assert an ip address when we do have sourceNat service
+            assertEquals("SourceNatIp returned by the VpcManager was not correctly set", publicIp, deployment.sourceNatIp);
+        } else {
+            // Assert null when we have no sourceNat service
+            assertEquals("SourceNatIp returned by the VpcManager was not correctly set", null, deployment.sourceNatIp);
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR introduces VPCs without SourceNat service. The goal is to have VPC that is not the default gateway for its guest VMs. Instead, the `gateway` parameter that is supplied when creating a tier, is used in the DHCP response to the guest VMs.

To achieve this we make use of the services that are described in a VPC offering. One of these services is `SourceNat`. Without this service, it makes no sense for the VPC to be the gateway. So, when we have a VPC without `SourceNat` service, we will configure it as a bridge instead of a gateway.

**VPC does not have gateway ip address**
A VPC without a SourceNat service will get a random guest ip address from the DHCP pool, like redundant VPCs also do. Instead of creating a VIP address (like Redundant VPCs) we now assume this gateway address to be available somewhere in the network. Be it a physical or virtual device that is bridged in. The gateway address is being reserved and not assigned to guest VMs. Be aware that during a restart with cleanup of the VPC, its assigned guest nic per tier may change.

**No public ip address**
As a bonus, when no SourceNat service is defined in the offering and also no VPN service, there is no need for a public nic at all. In these cases, this PR makes sure that no public nic is provisioned. This is more secure, not wasting ip addresses and also leaves a nic for another tier or private gateway.

For this to work, special VPC and Tier offerings need to be used as documented in this PR.

**Creating the offerings**
We need both a VPC and a network offering for this to work.

_VPC offering for Bridged network_
Will not create a public nic.

```
CM="cloudmonkey"
$CM set display default
echo "Creating MCC-VPC-Bridge-NoRed VPC-offering"
SYSOFFERINGID=`$CM list serviceofferings issystem=true name="System Offering For Software Router" | grep ^id\ = | awk '{print $3}'`
UUID=`$CM create vpcoffering name=MCC-VPC-Bridge-NoRed displaytext=MCC-VPC-Bridge-NoRed isdefault=false supportedservices=UserData,Dhcp,Dns,NetworkACL,Gateway  serviceproviderlist[0].service=UserData serviceproviderlist[0].provider=VpcVirtualRouter serviceproviderlist[1].service=Dhcp serviceproviderlist[1].provider=VpcVirtualRouter serviceproviderlist[2].service=Dns serviceproviderlist[2].provider=VpcVirtualRouter  serviceproviderlist[3].service=NetworkACL serviceproviderlist[3].provider=VpcVirtualRouter serviceofferingid=$SYSOFFERINGID filter=id | grep ^id\ = | awk '{print $3}'`
echo "Enable VPC offering MCC-VPC-Bridge-NoRed with UUID=" $UUID
$CM update vpcoffering id=$UUID state=enabled
```

_VPC offering for Bridged network with VPN Service_
Will create a public nic for the VPN to use.

```
CM="cloudmonkey"
$CM set display default
echo "Creating MCC-VPC-Bridge-NoRed VPC-offering"
SYSOFFERINGID=`$CM list serviceofferings issystem=true name="System Offering For Software Router" | grep ^id\ = | awk '{print $3}'`
UUID=`$CM create vpcoffering name=MCC-VPC-Bridge-withVPN-NoRed displaytext=MCC-VPC-Bridge-withVPN-NoRed isdefault=false supportedservices=UserData,Dhcp,Dns,NetworkACL,VPN  serviceproviderlist[0].service=UserData serviceproviderlist[0].provider=VpcVirtualRouter serviceproviderlist[1].service=Dhcp serviceproviderlist[1].provider=VpcVirtualRouter serviceproviderlist[2].service=Dns serviceproviderlist[2].provider=VpcVirtualRouter  serviceproviderlist[3].service=NetworkACL serviceproviderlist[3].provider=VpcVirtualRouter serviceproviderlist[4].service=VPN serviceproviderlist[4].provider=VpcVirtualRouter serviceofferingid=$SYSOFFERINGID filter=id | grep ^id\ = | awk '{print $3}'`
echo "Enable VPC offering MCC-VPC-Bridge-withVPN-NoRed with UUID=" $UUID
$CM update vpcoffering id=$UUID state=enabled
```

_Network offering for tier in above VPCs_

```
CM="cloudmonkey"
echo "Creating MCC-VPC-Bridged Networkoffering"
UUID=`$CM create networkoffering ispersistent=true name=MCC-VPC-Bridged forvpc="true" conservemode=on maxconnections=16384 displaytext="VPC Network with Nicira NVP for Bridging Only" guestiptype=Isolated traffictype=GUEST egressdefaultpolicy=deny specifyvlan=False availability=Optional supportedservices=UserData,Dhcp,Dns,NetworkACL serviceproviderlist[0].service=UserData serviceproviderlist[0].provider=VpcVirtualRouter serviceproviderlist[1].service=Dhcp serviceproviderlist[1].provider=VpcVirtualRouter serviceproviderlist[2].service=Dns serviceproviderlist[2].provider=VpcVirtualRouter serviceproviderlist[3].service=NetworkACL serviceproviderlist[3].provider=VpcVirtualRouter filter=id | grep ^id\ = | awk '{print $3}'`
echo "Enable network offering MCC-VPC-Bridged with uuid=" $UUID
$CM update networkoffering id=$UUID state=enabled
```

Adding a VPC:
![screen shot 2016-05-31 at 19 31 54](https://cloud.githubusercontent.com/assets/1630096/15684219/67b05a22-2766-11e6-8716-a774624e4d47.png)

Adding a tier:
![screen shot 2016-05-31 at 19 46 10](https://cloud.githubusercontent.com/assets/1630096/15684660/647e95c4-2768-11e6-8ebf-985214f91389.png)

External gateway:
![image](https://cloud.githubusercontent.com/assets/1630096/15684378/292384ea-2767-11e6-9e03-4007d4a4cd26.png)

VPC router without public nic:
![vpc-no-public-nic](https://cloud.githubusercontent.com/assets/1630096/15684113/df593644-2765-11e6-8e51-5959c734397c.png)

With and without:
![screen shot 2016-05-31 at 19 30 02](https://cloud.githubusercontent.com/assets/1630096/15684165/25818b6c-2766-11e6-812d-3cb19a3e4a43.png)

![image](https://cloud.githubusercontent.com/assets/1630096/15684247/880ee036-2766-11e6-8e14-e0e23923e31b.png)
