### PR TITLE
Skip adding static routes on the backup router

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/cs/CsStaticRoutes.py
@@ -25,7 +25,14 @@ import sys
 class CsStaticRoutes(CsDataBag):
 
     def process(self):
+        is_master = self.cl.is_master()
+        if self.cl.is_redundant() and not is_master:
+            logging.debug("Not processing CsStaticRoutes file ==> %s because redundant state is %s" %
+                          (self.dbag, str(is_master)))
+            return True
+
         logging.debug("Processing CsStaticRoutes file ==> %s" % self.dbag)
+
         for item in self.dbag:
             if item == "id":
                 continue


### PR DESCRIPTION
As there is no UP interface, the static route adding fails. This has always failed, but recently I changed the "silent failure" for a non-zero exit so now we actually see it..

Green build again!
https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0020-tracking-repo-build/446/
