### PR TITLE
When a VPC does not provide SourceNat service, then associate ip call should fail

### DIFF
--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -2248,6 +2248,10 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         // check permissions
         _accountMgr.checkAccess(caller, null, true, owner, vpc);
 
+        if (! hasSourceNatService(vpc)) {
+            throw new InvalidParameterValueException("VPC does not support SourceNat service so no public ip addresses can be assigned.");
+        }
+
         boolean isSourceNat = false;
         if (getExistingSourceNatInVpc(owner.getId(), vpcId) == null) {
             isSourceNat = true;
@@ -2274,6 +2278,13 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
         s_logger.debug("Successfully assigned ip " + ipToAssoc + " to vpc " + vpc);
 
         return _ipAddressDao.findById(ipId);
+    }
+
+    private boolean hasSourceNatService(Vpc vpc) {
+        final Map<Network.Service, Set<Network.Provider>> vpcOffSvcProvidersMap = getVpcOffSvcProvidersMap(vpc.getVpcOfferingId());
+
+        return vpcOffSvcProvidersMap.containsKey(Network.Service.SourceNat) &&
+                vpcOffSvcProvidersMap.get(Network.Service.SourceNat).contains(Network.Provider.VPCVirtualRouter);
     }
 
     @Override


### PR DESCRIPTION
While testing I found that a VPC created with an offering that does not include SourceNat (and thus does not get an public ip address provisioned) could still request one. That wouldn't work, so we would just be wasting public ip addresses. 

This PR adds an error message notifying the user that no address will be assigned:
![screen shot 2016-06-09 at 22 11 37](https://cloud.githubusercontent.com/assets/1630096/15944947/42fcb546-2e90-11e6-926f-ef62802413d2.png)

When SourceNat service is available, assigning still works. Here you see one failure and one success:
![screen shot 2016-06-09 at 22 12 04](https://cloud.githubusercontent.com/assets/1630096/15944955/50cba722-2e90-11e6-9ffe-43045cfb1cd5.png)
